### PR TITLE
Improve Import resiliency

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,31 +1,14 @@
-import React, { useContext } from "react";
+import React from "react";
 import { Routes, Route, useLocation } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
-import { Modal, Spinner } from "react-bootstrap";
 import MyNavbar from "@/components/Navbar";
-import { ImportContext } from "@/context/ImportContext";
+import ImportOverlay from "@/components/ImportOverlay";
 import HomePage from "./pages/HomePage";
 import AppliancesPage from "./pages/AppliancesPage";
 import AppliancePage from "./pages/AppliancePage";
 import SpacePage from "./pages/SpacePage";
 import SettingsPage from "./pages/SettingsPage";
 import { APP_VERSION } from "./version";
-
-const ImportOverlay: React.FC = () => {
-  const { isImporting } = useContext(ImportContext);
-
-  return (
-    <Modal show={isImporting} backdrop="static" keyboard={false} centered>
-      <Modal.Body className="text-center py-5">
-        <Spinner animation="border" role="status" />
-        <p className="mt-3 mb-1 fw-bold">Import in progress...</p>
-        <p className="text-muted small mb-0">
-          Please do not close or navigate away from this page.
-        </p>
-      </Modal.Body>
-    </Modal>
-  );
-};
 
 const getPageName = (p: string) => {
   if (!p || p === "/") return "Home";

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,13 +1,31 @@
-import React from "react";
+import React, { useContext } from "react";
 import { Routes, Route, useLocation } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
+import { Modal, Spinner } from "react-bootstrap";
 import MyNavbar from "@/components/Navbar";
+import { ImportContext } from "@/context/ImportContext";
 import HomePage from "./pages/HomePage";
 import AppliancesPage from "./pages/AppliancesPage";
 import AppliancePage from "./pages/AppliancePage";
 import SpacePage from "./pages/SpacePage";
 import SettingsPage from "./pages/SettingsPage";
 import { APP_VERSION } from "./version";
+
+const ImportOverlay: React.FC = () => {
+  const { isImporting } = useContext(ImportContext);
+
+  return (
+    <Modal show={isImporting} backdrop="static" keyboard={false} centered>
+      <Modal.Body className="text-center py-5">
+        <Spinner animation="border" role="status" />
+        <p className="mt-3 mb-1 fw-bold">Import in progress...</p>
+        <p className="text-muted small mb-0">
+          Please do not close or navigate away from this page.
+        </p>
+      </Modal.Body>
+    </Modal>
+  );
+};
 
 const getPageName = (p: string) => {
   if (!p || p === "/") return "Home";
@@ -27,6 +45,7 @@ const App: React.FC = () => {
       <Helmet>
         <title>{`HomeLogger | ${pageName}`}</title>
       </Helmet>
+      <ImportOverlay />
       <div className="container">
         <MyNavbar />
         <main style={{ marginTop: 18 }}>

--- a/client/src/components/ImportOverlay.tsx
+++ b/client/src/components/ImportOverlay.tsx
@@ -1,0 +1,21 @@
+import React, { useContext } from "react";
+import { Modal, Spinner } from "react-bootstrap";
+import { ImportContext } from "@/context/ImportContext";
+
+const ImportOverlay: React.FC = () => {
+  const { isImporting } = useContext(ImportContext);
+
+  return (
+    <Modal show={isImporting} backdrop="static" keyboard={false}>
+      <Modal.Body className="text-center py-5">
+        <Spinner animation="border" role="status" />
+        <p className="mt-3 mb-1 fw-bold">Import in progress...</p>
+        <p className="text-muted small mb-0">
+          Please do not close or navigate away from this page.
+        </p>
+      </Modal.Body>
+    </Modal>
+  );
+};
+
+export default ImportOverlay;

--- a/client/src/context/ImportContext.tsx
+++ b/client/src/context/ImportContext.tsx
@@ -1,0 +1,11 @@
+import { createContext } from "react";
+
+export interface ImportContextValue {
+  isImporting: boolean;
+  setImporting: (v: boolean) => void;
+}
+
+export const ImportContext = createContext<ImportContextValue>({
+  isImporting: false,
+  setImporting: () => {},
+});

--- a/client/src/context/ImportProvider.tsx
+++ b/client/src/context/ImportProvider.tsx
@@ -1,0 +1,13 @@
+import { useState } from "react";
+import type { ReactNode } from "react";
+import { ImportContext } from "./ImportContext";
+
+export const ImportProvider = ({ children }: { children: ReactNode }) => {
+  const [isImporting, setImporting] = useState(false);
+
+  return (
+    <ImportContext.Provider value={{ isImporting, setImporting }}>
+      {children}
+    </ImportContext.Provider>
+  );
+};

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -5,6 +5,7 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import "bootstrap-icons/font/bootstrap-icons.css";
 import App from "./App";
 import { DemoProvider } from "./context/DemoContext";
+import { ImportProvider } from "./context/ImportProvider";
 import { HelmetProvider } from "react-helmet-async";
 import { BrowserRouter } from "react-router-dom";
 
@@ -12,9 +13,11 @@ createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <HelmetProvider>
       <DemoProvider>
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
+        <ImportProvider>
+          <BrowserRouter>
+            <App />
+          </BrowserRouter>
+        </ImportProvider>
       </DemoProvider>
     </HelmetProvider>
   </StrictMode>,

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState, type ChangeEvent } from "react";
-import { Button, Modal } from "react-bootstrap";
+import { Alert, Button, Modal } from "react-bootstrap";
 
 import { SERVER_URL } from "@/context/DemoContext";
 import { ImportContext } from "@/context/ImportContext";
@@ -8,6 +8,9 @@ const SettingsPage: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const { isImporting, setImporting } = useContext(ImportContext);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [showResultModal, setShowResultModal] = useState(false);
+  const [resultMessage, setResultMessage] = useState("");
+  const [resultIsSuccess, setResultIsSuccess] = useState(false);
   const [showFileSelectionModal, setShowFileSelectionModal] = useState(false);
   const [showOverwriteConfirmModal, setShowOverwriteConfirmModal] =
     useState(false);
@@ -62,17 +65,20 @@ const SettingsPage: React.FC = () => {
         );
       }
 
-      alert(
+      setResultMessage(
         `Backup imported successfully (${body.inserted || 0} records inserted)`,
       );
+      setResultIsSuccess(true);
       setSelectedFile(null);
     } catch (err: any) {
       console.error(err);
-      alert(
+      setResultMessage(
         `Error importing backup: ${err.message || "See console for details."}`,
       );
+      setResultIsSuccess(false);
     } finally {
       setImporting(false);
+      setShowResultModal(true);
     }
   };
 
@@ -188,6 +194,35 @@ const SettingsPage: React.FC = () => {
             {isImporting ? "Importing..." : "Import Data"}
           </Button>
         </Modal.Footer>
+      </Modal>
+
+      <Modal show={showResultModal} onHide={() => setShowResultModal(false)}>
+        <Modal.Header closeButton>
+          <Modal.Title>
+            <i
+              className={`bi ${resultIsSuccess ? "bi-check-circle-fill text-success" : "bi-x-circle-fill text-danger"}`}
+              style={{ marginRight: 8 }}
+            />
+            {resultIsSuccess ? "Import Successful" : "Import Failed"}
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Alert variant={resultIsSuccess ? "success" : "danger"} className="mb-0">
+            {resultMessage}
+          </Alert>
+          {!resultIsSuccess && (
+            <p className="text-center mt-3 mb-0">
+              <a
+                href="https://github.com/FrancisLaboratories/homelogger/issues"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <i className="bi bi-github me-1" />
+                Submit a GitHub issue if this keeps happening
+              </a>
+            </p>
+          )}
+        </Modal.Body>
       </Modal>
     </div>
   );

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -57,10 +57,14 @@ const SettingsPage: React.FC = () => {
       const body = await res.json();
 
       if (!res.ok) {
-        throw new Error(`Failed to import backup: ${body.error || "Unknown error"}`);
+        throw new Error(
+          `Failed to import backup: ${body.error || "Unknown error"}`,
+        );
       }
 
-      alert(`Backup imported successfully (${body.inserted || 0} records inserted)`);
+      alert(
+        `Backup imported successfully (${body.inserted || 0} records inserted)`,
+      );
       setSelectedFile(null);
     } catch (err: any) {
       console.error(err);

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -1,11 +1,12 @@
-import React, { useState, type ChangeEvent } from "react";
+import React, { useContext, useState, type ChangeEvent } from "react";
 import { Button, Modal } from "react-bootstrap";
 
 import { SERVER_URL } from "@/context/DemoContext";
+import { ImportContext } from "@/context/ImportContext";
 
 const SettingsPage: React.FC = () => {
   const [loading, setLoading] = useState(false);
-  const [importLoading, setImportLoading] = useState(false);
+  const { isImporting, setImporting } = useContext(ImportContext);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [showFileSelectionModal, setShowFileSelectionModal] = useState(false);
   const [showOverwriteConfirmModal, setShowOverwriteConfirmModal] =
@@ -29,7 +30,6 @@ const SettingsPage: React.FC = () => {
   };
 
   const handleImportBackupClick = () => {
-    // This will now be the trigger for the confirmation modal, not the import itself
     if (!selectedFile) {
       alert("Please select a backup file to import.");
       return;
@@ -39,8 +39,8 @@ const SettingsPage: React.FC = () => {
 
   const handleConfirmImport = async () => {
     setShowOverwriteConfirmModal(false);
-    setShowFileSelectionModal(false); // Close file selection modal too
-    setImportLoading(true);
+    setShowFileSelectionModal(false);
+    setImporting(true);
     try {
       const formData = new FormData();
       if (selectedFile) {
@@ -72,7 +72,7 @@ const SettingsPage: React.FC = () => {
         `Error importing backup: ${err.message || "See console for details."}`,
       );
     } finally {
-      setImportLoading(false);
+      setImporting(false);
     }
   };
 
@@ -182,10 +182,10 @@ const SettingsPage: React.FC = () => {
           </Button>
           <Button
             onClick={handleImportBackupClick}
-            disabled={importLoading || !selectedFile}
+            disabled={isImporting || !selectedFile}
             variant="danger"
           >
-            {importLoading ? "Importing..." : "Import Data"}
+            {isImporting ? "Importing..." : "Import Data"}
           </Button>
         </Modal.Footer>
       </Modal>

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -207,7 +207,10 @@ const SettingsPage: React.FC = () => {
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          <Alert variant={resultIsSuccess ? "success" : "danger"} className="mb-0">
+          <Alert
+            variant={resultIsSuccess ? "success" : "danger"}
+            className="mb-0"
+          >
             {resultMessage}
           </Alert>
           {!resultIsSuccess && (

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -54,12 +54,13 @@ const SettingsPage: React.FC = () => {
         body: formData,
       });
 
+      const body = await res.json();
+
       if (!res.ok) {
-        const errorText = await res.text();
-        throw new Error(`Failed to import backup: ${errorText}`);
+        throw new Error(`Failed to import backup: ${body.error || "Unknown error"}`);
       }
 
-      alert("Backup imported successfully");
+      alert(`Backup imported successfully (${body.inserted || 0} records inserted)`);
       setSelectedFile(null);
     } catch (err: any) {
       console.error(err);

--- a/server/cmd/server/handler_health.go
+++ b/server/cmd/server/handler_health.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"sync/atomic"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/masoncfrancis/homelogger/server/internal/version"
+	"gorm.io/gorm"
+)
+
+func HealthHandler(db *gorm.DB, demoMode bool, importing *atomic.Bool) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		dbSQL, err := db.DB()
+		dbStatus := "ok"
+		if err != nil {
+			dbStatus = "error: " + err.Error()
+		} else if err := dbSQL.Ping(); err != nil {
+			dbStatus = "error: " + err.Error()
+		}
+
+		status := fiber.Map{
+			"status":    "ok",
+			"version":   version.Version,
+			"db":        dbStatus,
+			"demo":      demoMode,
+			"importing": importing.Load(),
+		}
+
+		if dbStatus != "ok" {
+			return c.Status(fiber.StatusInternalServerError).JSON(status)
+		}
+
+		return c.Status(fiber.StatusOK).JSON(status)
+	}
+}

--- a/server/cmd/server/handler_import.go
+++ b/server/cmd/server/handler_import.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"archive/zip"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/masoncfrancis/homelogger/server/internal/database"
+	"github.com/masoncfrancis/homelogger/server/internal/models"
+	"gorm.io/gorm"
+)
+
+func ImportBackupHandler(db *gorm.DB, importing *atomic.Bool, backupMu *sync.Mutex) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		backupMu.Lock()
+		defer backupMu.Unlock()
+
+		importing.Store(true)
+		defer importing.Store(false)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+
+		file, err := c.FormFile("backup")
+		if err != nil {
+			return c.Status(fiber.StatusBadRequest).SendString("Error getting backup file: " + err.Error())
+		}
+
+		tempDir, err := os.MkdirTemp("", "homelogger-backup-import-")
+		if err != nil {
+			return c.Status(fiber.StatusInternalServerError).SendString("Error creating temp directory: " + err.Error())
+		}
+		defer func() { _ = os.RemoveAll(tempDir) }()
+
+		tempZipPath := filepath.Join(tempDir, file.Filename)
+		if err := c.SaveFile(file, tempZipPath); err != nil {
+			return c.Status(fiber.StatusInternalServerError).SendString("Error saving uploaded file: " + err.Error())
+		}
+
+		r, err := zip.OpenReader(tempZipPath)
+		if err != nil {
+			return c.Status(fiber.StatusInternalServerError).SendString("Error opening zip file: " + err.Error())
+		}
+		defer func() { _ = r.Close() }()
+
+		extractedPath := filepath.Join(tempDir, "extracted")
+		if err := os.MkdirAll(extractedPath, 0755); err != nil {
+			return c.Status(fiber.StatusInternalServerError).SendString("Error creating extraction directory: " + err.Error())
+		}
+
+		var dataJSONPath string
+		var legacyDBPath string
+		var uploadsExtractedPath string
+		var nestedDataJSON string
+		var nestedLegacyDB string
+		var nestedUploads string
+
+		for _, f := range r.File {
+			if err := ctx.Err(); err != nil {
+				return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+					"status": "failed",
+					"error":  "Import timed out during ZIP extraction",
+				})
+			}
+			fpath := filepath.Join(extractedPath, f.Name)
+			if !strings.HasPrefix(fpath, filepath.Clean(extractedPath)+string(os.PathSeparator)) {
+				return c.Status(fiber.StatusBadRequest).SendString("Illegal file path in zip: " + fpath)
+			}
+			if f.FileInfo().IsDir() {
+				_ = os.MkdirAll(fpath, os.ModePerm)
+				continue
+			}
+			if err = os.MkdirAll(filepath.Dir(fpath), os.ModePerm); err != nil {
+				return c.Status(fiber.StatusInternalServerError).SendString("Error creating dir: " + err.Error())
+			}
+			outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+			if err != nil {
+				return c.Status(fiber.StatusInternalServerError).SendString("Error creating file: " + err.Error())
+			}
+			rc, err := f.Open()
+			if err != nil {
+				_ = outFile.Close()
+				return c.Status(fiber.StatusInternalServerError).SendString("Error opening zip entry: " + err.Error())
+			}
+			_, copyErr := io.Copy(outFile, rc)
+			_ = outFile.Close()
+			_ = rc.Close()
+			if copyErr != nil {
+				return c.Status(fiber.StatusInternalServerError).SendString("Error extracting file: " + copyErr.Error())
+			}
+			switch {
+			case f.Name == "data.json":
+				dataJSONPath = fpath
+			case strings.HasSuffix(f.Name, "/data.json") && nestedDataJSON == "":
+				nestedDataJSON = f.Name
+			}
+			if strings.HasPrefix(f.Name, "db/") && strings.HasSuffix(strings.ToLower(f.Name), ".db") && legacyDBPath == "" {
+				legacyDBPath = fpath
+			} else if strings.Contains(f.Name, "/db/") && strings.HasSuffix(strings.ToLower(f.Name), ".db") && nestedLegacyDB == "" {
+				nestedLegacyDB = f.Name
+			}
+			if strings.HasPrefix(f.Name, "uploads/") && uploadsExtractedPath == "" {
+				uploadsExtractedPath = filepath.Join(extractedPath, "uploads")
+			} else if strings.Contains(f.Name, "/uploads/") && nestedUploads == "" {
+				nestedUploads = f.Name
+			}
+		}
+
+		if err := ctx.Err(); err != nil {
+			return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+				"status": "failed",
+				"error":  "Import timed out before database import",
+			})
+		}
+
+		if dataJSONPath == "" && nestedDataJSON != "" {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"status": "failed",
+				"error":  fmt.Sprintf("data.json was found inside %q — place it at the root of the ZIP archive", nestedDataJSON),
+			})
+		}
+		if dataJSONPath != "" && uploadsExtractedPath == "" && nestedUploads != "" {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"status": "failed",
+				"error":  fmt.Sprintf("uploads folder was found inside %q — place uploads/ at the root of the ZIP archive", nestedUploads),
+			})
+		}
+
+		dbCtx := db.WithContext(ctx)
+		var importResult *models.ImportResult
+		switch {
+		case dataJSONPath != "":
+			importResult, err = database.ImportFromJSONFile(dbCtx, dataJSONPath, uploadsExtractedPath)
+			if err != nil {
+				return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+					"status":   "failed",
+					"importId": importResult.GetImportID(),
+					"error":    "Error importing database data: " + err.Error(),
+				})
+			}
+		case legacyDBPath != "":
+			payload, convErr := database.ConvertLegacyDB(legacyDBPath)
+			if convErr != nil {
+				return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+					"status": "failed",
+					"error":  "Error reading legacy backup: " + convErr.Error(),
+				})
+			}
+			importResult, err = database.ImportFromJSON(dbCtx, payload, uploadsExtractedPath)
+			if err != nil {
+				return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+					"status":   "failed",
+					"importId": importResult.GetImportID(),
+					"error":    "Error importing database data: " + err.Error(),
+				})
+			}
+		default:
+			msg := "Backup ZIP must contain data.json (new format) or a .db file in a db/ directory (legacy format)"
+			switch {
+			case nestedDataJSON != "":
+				msg += fmt.Sprintf(" data.json was found inside %q — place it at the root of the ZIP", nestedDataJSON)
+			case nestedLegacyDB != "":
+				msg += fmt.Sprintf(" legacy database was found inside %q — place it at the root of the ZIP", nestedLegacyDB)
+			}
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"status": "failed",
+				"error":  msg,
+			})
+		}
+
+		if err := ctx.Err(); err != nil {
+			database.FailImport(db, importResult.ImportID, "import timed out after database import")
+			return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+				"status":   "failed",
+				"importId": importResult.ImportID,
+				"error":    "Import timed out after database import — uploads were not restored",
+			})
+		}
+
+		if err := database.ImportUploads(uploadsExtractedPath); err != nil {
+			database.FailImport(db, importResult.ImportID, err.Error())
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+				"status":   "failed",
+				"importId": importResult.ImportID,
+				"inserted": importResult.Inserted,
+				"error":    "Error importing uploaded files: " + err.Error(),
+			})
+		}
+
+		database.CompleteImport(db, importResult.ImportID)
+		return c.JSON(fiber.Map{
+			"status":   "completed",
+			"importId": importResult.ImportID,
+			"inserted": importResult.Inserted,
+		})
+	}
+}

--- a/server/cmd/server/health_test.go
+++ b/server/cmd/server/health_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+)
+
+func TestHealthEndpoint_ImportingField(t *testing.T) {
+	t.Run("normal state shows importing false", func(t *testing.T) {
+		var importing atomic.Bool
+
+		app := fiber.New()
+		app.Get("/api/health", func(c fiber.Ctx) error {
+			return c.JSON(fiber.Map{
+				"status":    "ok",
+				"importing": importing.Load(),
+			})
+		})
+
+		req := httptest.NewRequest("GET", "/api/health", nil)
+		resp, _ := app.Test(req)
+
+		var body map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&body)
+		if body["importing"] != false {
+			t.Errorf("expected importing=false, got %v", body["importing"])
+		}
+	})
+
+	t.Run("while importing shows importing true", func(t *testing.T) {
+		var importing atomic.Bool
+		importing.Store(true)
+
+		app := fiber.New()
+		app.Get("/api/health", func(c fiber.Ctx) error {
+			return c.JSON(fiber.Map{
+				"status":    "ok",
+				"importing": importing.Load(),
+			})
+		})
+
+		req := httptest.NewRequest("GET", "/api/health", nil)
+		resp, _ := app.Test(req)
+
+		var body map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&body)
+		if body["importing"] != true {
+			t.Errorf("expected importing=true, got %v", body["importing"])
+		}
+	})
+
+	t.Run("real health handler with db", func(t *testing.T) {
+		db := openTestDB(t)
+		var importing atomic.Bool
+
+		app := fiber.New()
+		app.Get("/api/health", HealthHandler(db, false, &importing))
+
+		req := httptest.NewRequest("GET", "/api/health", nil)
+		resp, _ := app.Test(req)
+		if resp.StatusCode != fiber.StatusOK {
+			t.Errorf("expected 200, got %d", resp.StatusCode)
+		}
+
+		var body map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&body)
+		if body["importing"] != false {
+			t.Errorf("expected importing=false, got %v", body["importing"])
+		}
+		if body["status"] != "ok" {
+			t.Errorf("expected status ok, got %v", body["status"])
+		}
+		if body["db"] != "ok" {
+			t.Errorf("expected db ok, got %v", body["db"])
+		}
+	})
+}

--- a/server/cmd/server/import_db_test.go
+++ b/server/cmd/server/import_db_test.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/masoncfrancis/homelogger/server/internal/database"
+	"github.com/masoncfrancis/homelogger/server/internal/models"
+)
+
+func TestImportFromJSON_AllEntities(t *testing.T) {
+	db := openTestDB(t)
+
+	payload := &models.BackupPayload{
+		Version:      database.BackupVersion,
+		DatabaseType: db.Dialector.Name(),
+		Entities: models.Entities{
+			Appliances: []models.Appliance{
+				{ApplianceName: "Fridge"},
+				{ApplianceName: "Washer"},
+			},
+			Todos: []models.Todo{
+				{UserID: "user1"},
+				{UserID: "user2"},
+			},
+			Maintenance: []models.Maintenance{
+				{Description: "Filter change", Date: "2026-01-15"},
+			},
+			Repairs: []models.Repair{
+				{Description: "Fix leak", Date: "2026-03-01"},
+			},
+			SavedFiles: []models.SavedFile{
+				{Path: "./data/uploads/1", OriginalName: "doc.pdf", UserID: "u1"},
+			},
+			Notes: []models.Note{
+				{Title: "Note 1", Body: "Body 1"},
+			},
+			Tasks: []models.Task{
+				{Label: "Task 1", UserID: "u1"},
+				{Label: "Task 2", UserID: "u2"},
+			},
+		},
+	}
+
+	result, err := database.ImportFromJSON(db, payload, "")
+	if err != nil {
+		t.Fatalf("import failed: %v", err)
+	}
+
+	expected := 10 // 2 + 2 + 1 + 1 + 1 + 1 + 2
+	if result.Inserted != expected {
+		t.Errorf("expected %d inserted records, got %d", expected, result.Inserted)
+	}
+
+	var appliances []models.Appliance
+	if err := db.Find(&appliances).Error; err != nil {
+		t.Fatalf("query appliances: %v", err)
+	}
+	if len(appliances) != 2 {
+		t.Errorf("expected 2 appliances, got %d", len(appliances))
+	}
+
+	var todos []models.Todo
+	if err := db.Find(&todos).Error; err != nil {
+		t.Fatalf("query todos: %v", err)
+	}
+	if len(todos) != 2 {
+		t.Errorf("expected 2 todos, got %d", len(todos))
+	}
+
+	var maintenance []models.Maintenance
+	if err := db.Find(&maintenance).Error; err != nil {
+		t.Fatalf("query maintenance: %v", err)
+	}
+	if len(maintenance) != 1 {
+		t.Errorf("expected 1 maintenance, got %d", len(maintenance))
+	}
+
+	var repairs []models.Repair
+	if err := db.Find(&repairs).Error; err != nil {
+		t.Fatalf("query repairs: %v", err)
+	}
+	if len(repairs) != 1 {
+		t.Errorf("expected 1 repair, got %d", len(repairs))
+	}
+
+	var savedFiles []models.SavedFile
+	if err := db.Find(&savedFiles).Error; err != nil {
+		t.Fatalf("query savedFiles: %v", err)
+	}
+	if len(savedFiles) != 1 {
+		t.Errorf("expected 1 savedFile, got %d", len(savedFiles))
+	}
+
+	var notes []models.Note
+	if err := db.Find(&notes).Error; err != nil {
+		t.Fatalf("query notes: %v", err)
+	}
+	if len(notes) != 1 {
+		t.Errorf("expected 1 note, got %d", len(notes))
+	}
+
+	var tasks []models.Task
+	if err := db.Find(&tasks).Error; err != nil {
+		t.Fatalf("query tasks: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Errorf("expected 2 tasks, got %d", len(tasks))
+	}
+}
+
+func TestImportFromJSON_EmptyPayload(t *testing.T) {
+	db := openTestDB(t)
+
+	payload := &models.BackupPayload{
+		Version:      database.BackupVersion,
+		DatabaseType: db.Dialector.Name(),
+	}
+
+	result, err := database.ImportFromJSON(db, payload, "")
+	if err != nil {
+		t.Fatalf("expected success with empty payload, got %v", err)
+	}
+	if result.Inserted != 0 {
+		t.Errorf("expected 0 inserted, got %d", result.Inserted)
+	}
+
+	// Verify all tables exist and are empty
+	var count int64
+	db.Model(&models.Appliance{}).Count(&count)
+	if count != 0 {
+		t.Errorf("expected 0 appliances, got %d", count)
+	}
+}
+
+func TestImportFromJSON_UploadValidationFails(t *testing.T) {
+	db := openTestDB(t)
+
+	tempDir := t.TempDir()
+	payload := &models.BackupPayload{
+		Version:      database.BackupVersion,
+		DatabaseType: db.Dialector.Name(),
+		Entities: models.Entities{
+			SavedFiles: []models.SavedFile{
+				{Path: "./data/uploads/missing-file", OriginalName: "doc.pdf", UserID: "u1"},
+			},
+		},
+	}
+
+	// The validation should fail because missing-file doesn't exist in tempDir
+	_, err := database.ImportFromJSON(db, payload, tempDir)
+	if err == nil {
+		t.Fatal("expected error for missing upload file, got nil")
+	}
+}
+
+func TestImportFromJSON_WipesExistingData(t *testing.T) {
+	db := openTestDB(t)
+
+	// Insert pre-existing data
+	if err := db.Create(&models.Appliance{ApplianceName: "Old Fridge"}).Error; err != nil {
+		t.Fatalf("insert pre-existing: %v", err)
+	}
+
+	payload := &models.BackupPayload{
+		Version:      database.BackupVersion,
+		DatabaseType: db.Dialector.Name(),
+		Entities: models.Entities{
+			Appliances: []models.Appliance{
+				{ApplianceName: "New Fridge"},
+			},
+		},
+	}
+
+	result, err := database.ImportFromJSON(db, payload, "")
+	if err != nil {
+		t.Fatalf("import failed: %v", err)
+	}
+	if result.Inserted != 1 {
+		t.Errorf("expected 1 inserted, got %d", result.Inserted)
+	}
+
+	var count int64
+	db.Model(&models.Appliance{}).Count(&count)
+	if count != 1 {
+		t.Fatalf("expected 1 appliance after import, got %d", count)
+	}
+
+	var appliances []models.Appliance
+	db.Find(&appliances)
+	if appliances[0].ApplianceName != "New Fridge" {
+		t.Errorf("expected 'New Fridge', got %q", appliances[0].ApplianceName)
+	}
+}
+
+

--- a/server/cmd/server/import_handler_test.go
+++ b/server/cmd/server/import_handler_test.go
@@ -1,0 +1,345 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/masoncfrancis/homelogger/server/internal/database"
+	"github.com/masoncfrancis/homelogger/server/internal/models"
+	"gorm.io/gorm"
+)
+
+type testAppConfig struct {
+	db        *gorm.DB
+	importing *atomic.Bool
+	backupMu  *sync.Mutex
+}
+
+func createTestApp(cfg testAppConfig) *fiber.App {
+	app := fiber.New(fiber.Config{BodyLimit: 100 * 1024 * 1024})
+
+	app.Use(ImportLockMiddleware(cfg.importing))
+
+	api := app.Group("/api")
+
+	api.Get("/health", func(c fiber.Ctx) error {
+		return c.JSON(fiber.Map{"status": "ok", "importing": cfg.importing.Load()})
+	})
+
+	api.Post("/backup/import", ImportBackupHandler(cfg.db, cfg.importing, cfg.backupMu))
+
+	api.Get("/appliances", func(c fiber.Ctx) error {
+		var apps []models.Appliance
+		if err := cfg.db.Find(&apps).Error; err != nil {
+			return c.Status(500).SendString(err.Error())
+		}
+		return c.JSON(apps)
+	})
+
+	return app
+}
+
+func createTestBackupZIP(t *testing.T, payload *models.BackupPayload) ([]byte, string) {
+	t.Helper()
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+
+	f, err := w.Create("data.json")
+	if err != nil {
+		t.Fatalf("create zip entry: %v", err)
+	}
+	if _, err := f.Write(data); err != nil {
+		t.Fatalf("write data.json: %v", err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+
+	return buf.Bytes(), "test-backup.zip"
+}
+
+func multipartRequest(url string, zipData []byte, filename string) *http.Request {
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+
+	fw, _ := w.CreateFormFile("backup", filename)
+	fw.Write(zipData)
+	w.Close()
+
+	req := httptest.NewRequest("POST", url, &buf)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	return req
+}
+
+func TestImportHandler_Success(t *testing.T) {
+	db := openTestDB(t)
+	var importing atomic.Bool
+	var mu sync.Mutex
+
+	app := createTestApp(testAppConfig{
+		db:        db,
+		importing: &importing,
+		backupMu:  &mu,
+	})
+
+	payload := &models.BackupPayload{
+		Version:      database.BackupVersion,
+		DatabaseType: db.Dialector.Name(),
+		Entities: models.Entities{
+			Appliances: []models.Appliance{
+				{ApplianceName: "Test Fridge"},
+			},
+		},
+	}
+
+	zipData, filename := createTestBackupZIP(t, payload)
+	req := multipartRequest("/api/backup/import", zipData, filename)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var body map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if body["status"] != "completed" {
+		t.Errorf("expected status 'completed', got %v", body["status"])
+	}
+	if body["importId"] == nil || body["importId"] == "" {
+		t.Error("expected non-empty importId")
+	}
+	if body["inserted"] != float64(1) {
+		t.Errorf("expected inserted 1, got %v", body["inserted"])
+	}
+
+	// Verify data was actually imported
+	var count int64
+	db.Model(&models.Appliance{}).Count(&count)
+	if count != 1 {
+		t.Errorf("expected 1 appliance in DB, got %d", count)
+	}
+}
+
+func TestImportHandler_NoFile(t *testing.T) {
+	db := openTestDB(t)
+	var importing atomic.Bool
+	var mu sync.Mutex
+
+	app := createTestApp(testAppConfig{
+		db:        db,
+		importing: &importing,
+		backupMu:  &mu,
+	})
+
+	req := httptest.NewRequest("POST", "/api/backup/import", nil)
+	req.Header.Set("Content-Type", "multipart/form-data; boundary=test")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
+	if resp.StatusCode != fiber.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestImportHandler_NestedDataJSON(t *testing.T) {
+	db := openTestDB(t)
+	var importing atomic.Bool
+	var mu sync.Mutex
+
+	app := createTestApp(testAppConfig{
+		db:        db,
+		importing: &importing,
+		backupMu:  &mu,
+	})
+
+	payload := &models.BackupPayload{
+		Version:      database.BackupVersion,
+		DatabaseType: db.Dialector.Name(),
+		Entities: models.Entities{
+			Appliances: []models.Appliance{
+				{ApplianceName: "Fridge"},
+			},
+		},
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	f, _ := w.Create("subdir/data.json")
+	f.Write(data)
+	w.Close()
+
+	req := multipartRequest("/api/backup/import", buf.Bytes(), "nested.zip")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
+	if resp.StatusCode != fiber.StatusBadRequest {
+		t.Fatalf("expected 400 for nested data.json, got %d", resp.StatusCode)
+	}
+
+	var body map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&body)
+	if body["status"] != "failed" {
+		t.Errorf("expected status 'failed', got %v", body["status"])
+	}
+}
+
+func TestImportHandler_MissingDataJSON(t *testing.T) {
+	db := openTestDB(t)
+	var importing atomic.Bool
+	var mu sync.Mutex
+
+	app := createTestApp(testAppConfig{
+		db:        db,
+		importing: &importing,
+		backupMu:  &mu,
+	})
+
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	f, _ := w.Create("some-file.txt")
+	f.Write([]byte("hello"))
+	w.Close()
+
+	req := multipartRequest("/api/backup/import", buf.Bytes(), "no-data.zip")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
+	if resp.StatusCode != fiber.StatusBadRequest {
+		t.Fatalf("expected 400 for missing data.json, got %d", resp.StatusCode)
+	}
+}
+
+func TestImportHandler_MalformedZIP(t *testing.T) {
+	db := openTestDB(t)
+	var importing atomic.Bool
+	var mu sync.Mutex
+
+	app := createTestApp(testAppConfig{
+		db:        db,
+		importing: &importing,
+		backupMu:  &mu,
+	})
+
+	// Send garbage instead of a valid ZIP
+	req := multipartRequest("/api/backup/import", []byte("not-a-zip-file"), "bad.zip")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
+	if resp.StatusCode != fiber.StatusInternalServerError {
+		t.Fatalf("expected 500 for malformed zip, got %d", resp.StatusCode)
+	}
+}
+
+func TestImportHandler_WithUploads(t *testing.T) {
+	db := openTestDB(t)
+	var importing atomic.Bool
+	var mu sync.Mutex
+
+	app := createTestApp(testAppConfig{
+		db:        db,
+		importing: &importing,
+		backupMu:  &mu,
+	})
+
+	payload := &models.BackupPayload{
+		Version:      database.BackupVersion,
+		DatabaseType: db.Dialector.Name(),
+		Entities: models.Entities{
+			Appliances: []models.Appliance{
+				{ApplianceName: "Fridge"},
+			},
+			SavedFiles: []models.SavedFile{
+				{Path: "./data/uploads/photo.jpg", OriginalName: "photo.jpg", UserID: "u1"},
+			},
+		},
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+
+	f, _ := w.Create("data.json")
+	f.Write(data)
+
+	f, _ = w.Create("uploads/photo.jpg")
+	f.Write([]byte("photo-data"))
+
+	w.Close()
+
+	// Need ./data to exist for ImportUploads
+	if err := os.MkdirAll("./data", 0755); err != nil {
+		t.Fatalf("mkdir data: %v", err)
+	}
+
+	req := multipartRequest("/api/backup/import", buf.Bytes(), "with-uploads.zip")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected 200, got %d. Response: %s", resp.StatusCode, readBody(resp))
+	}
+
+	var body map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&body)
+	if body["status"] != "completed" {
+		t.Errorf("expected 'completed', got %v", body["status"])
+	}
+
+	// Clean up the uploaded files
+	os.RemoveAll("./data/uploads")
+	os.RemoveAll("./data/uploads.bak")
+
+	// Also clean up any temp directories created by ImportUploads
+	tempDirs, _ := filepath.Glob("./data/uploads-import-*")
+	for _, d := range tempDirs {
+		os.RemoveAll(d)
+	}
+}
+
+func readBody(r *http.Response) string {
+	b, _ := io.ReadAll(r.Body)
+	return string(b)
+}

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"archive/zip"
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -13,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -27,6 +29,7 @@ import (
 
 var backupMu sync.Mutex
 var demoMu sync.Mutex
+var importing atomic.Bool
 
 func main() {
 	// CLI flags
@@ -199,6 +202,19 @@ func main() {
 	logWriter := newLogWriter()
 	app.Use(requestLogger(logWriter))
 
+	// Import-lock middleware — blocks all non-critical API calls during backup import
+	app.Use(func(c fiber.Ctx) error {
+		if importing.Load() && strings.HasPrefix(c.Path(), "/api/") {
+			if c.Path() != "/api/health" && c.Path() != "/api/backup/import" {
+				return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+					"status":  "busy",
+					"message": "Server is restoring a backup. Please wait...",
+				})
+			}
+		}
+		return c.Next()
+	})
+
 	// API routes grouped under /api
 	api := app.Group("/api")
 
@@ -214,10 +230,11 @@ func main() {
 		}
 
 		status := fiber.Map{
-			"status":  "ok",
-			"version": version.Version,
-			"db":      dbStatus,
-			"demo":    demoMode,
+			"status":     "ok",
+			"version":    version.Version,
+			"db":         dbStatus,
+			"demo":       demoMode,
+			"importing":  importing.Load(),
 		}
 
 		// If DB is not ok, return 500
@@ -1269,6 +1286,12 @@ func main() {
 		backupMu.Lock()
 		defer backupMu.Unlock()
 
+		importing.Store(true)
+		defer importing.Store(false)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+
 		file, err := c.FormFile("backup")
 		if err != nil {
 			return c.Status(fiber.StatusBadRequest).SendString("Error getting backup file: " + err.Error())
@@ -1301,6 +1324,12 @@ func main() {
 		var uploadsExtractedPath string
 
 		for _, f := range r.File {
+			if err := ctx.Err(); err != nil {
+				return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+					"status": "failed",
+					"error":  "Import timed out during ZIP extraction",
+				})
+			}
 			fpath := filepath.Join(extractedPath, f.Name)
 			if !strings.HasPrefix(fpath, filepath.Clean(extractedPath)+string(os.PathSeparator)) {
 				return c.Status(fiber.StatusBadRequest).SendString("Illegal file path in zip: " + fpath)
@@ -1336,10 +1365,18 @@ func main() {
 			}
 		}
 
+		if err := ctx.Err(); err != nil {
+			return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+				"status": "failed",
+				"error":  "Import timed out before database import",
+			})
+		}
+
+		dbCtx := db.WithContext(ctx)
 		var importResult *models.ImportResult
 		switch {
 		case dataJSONPath != "":
-			importResult, err = database.ImportFromJSONFile(db, dataJSONPath, uploadsExtractedPath)
+			importResult, err = database.ImportFromJSONFile(dbCtx, dataJSONPath, uploadsExtractedPath)
 			if err != nil {
 				return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 					"status":   "failed",
@@ -1355,7 +1392,7 @@ func main() {
 					"error":  "Error reading legacy backup: " + err.Error(),
 				})
 			}
-			importResult, err = database.ImportFromJSON(db, payload, uploadsExtractedPath)
+			importResult, err = database.ImportFromJSON(dbCtx, payload, uploadsExtractedPath)
 			if err != nil {
 				return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 					"status":   "failed",
@@ -1367,6 +1404,15 @@ func main() {
 			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 				"status": "failed",
 				"error":  "Backup ZIP must contain data.json (new format) or a .db file in a db/ directory (legacy format)",
+			})
+		}
+
+		if err := ctx.Err(); err != nil {
+			database.FailImport(db, importResult.ImportID, "import timed out after database import")
+			return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+				"status":   "failed",
+				"importId": importResult.ImportID,
+				"error":    "Import timed out after database import — uploads were not restored",
 			})
 		}
 

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -1341,28 +1341,51 @@ func main() {
 		case dataJSONPath != "":
 			importResult, err = database.ImportFromJSONFile(db, dataJSONPath, uploadsExtractedPath)
 			if err != nil {
-				return c.Status(fiber.StatusInternalServerError).SendString("Error importing database data: " + err.Error())
+				return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+					"status":   "failed",
+					"importId": importResult.GetImportID(),
+					"error":    "Error importing database data: " + err.Error(),
+				})
 			}
 		case legacyDBPath != "":
 			payload, err := database.ConvertLegacyDB(legacyDBPath)
 			if err != nil {
-				return c.Status(fiber.StatusInternalServerError).SendString("Error reading legacy backup: " + err.Error())
+				return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+					"status": "failed",
+					"error":  "Error reading legacy backup: " + err.Error(),
+				})
 			}
 			importResult, err = database.ImportFromJSON(db, payload, uploadsExtractedPath)
 			if err != nil {
-				return c.Status(fiber.StatusInternalServerError).SendString("Error importing database data: " + err.Error())
+				return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+					"status":   "failed",
+					"importId": importResult.GetImportID(),
+					"error":    "Error importing database data: " + err.Error(),
+				})
 			}
 		default:
-			return c.Status(fiber.StatusBadRequest).SendString("Backup ZIP must contain data.json (new format) or a .db file in a db/ directory (legacy format)")
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"status": "failed",
+				"error":  "Backup ZIP must contain data.json (new format) or a .db file in a db/ directory (legacy format)",
+			})
 		}
 
 		if err := database.ImportUploads(uploadsExtractedPath); err != nil {
 			database.FailImport(db, importResult.ImportID, err.Error())
-			return c.Status(fiber.StatusInternalServerError).SendString("Error importing uploaded files: " + err.Error())
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+				"status":   "failed",
+				"importId": importResult.ImportID,
+				"inserted": importResult.Inserted,
+				"error":    "Error importing uploaded files: " + err.Error(),
+			})
 		}
 
 		database.CompleteImport(db, importResult.ImportID)
-		return c.SendString("Backup import completed successfully")
+		return c.JSON(fiber.Map{
+			"status":   "completed",
+			"importId": importResult.ImportID,
+			"inserted": importResult.Inserted,
+		})
 	})
 
 	// Serve static SPA files with client-side routing fallback

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -64,6 +64,10 @@ func main() {
 		fmt.Printf("Warning: todo→task migration failed: %v\n", err)
 	}
 
+	if msg := database.CheckImportLog(db); msg != "" {
+		fmt.Print(msg)
+	}
+
 	if demoMode && db != nil && db.Dialector.Name() == "postgres" {
 		fmt.Println("Warning: DEMO_MODE is only supported with SQLite; disabling demo mode for PostgreSQL")
 		demoMode = false
@@ -1332,9 +1336,11 @@ func main() {
 			}
 		}
 
+		var importResult *models.ImportResult
 		switch {
 		case dataJSONPath != "":
-			if _, err := database.ImportFromJSONFile(db, dataJSONPath, uploadsExtractedPath); err != nil {
+			importResult, err = database.ImportFromJSONFile(db, dataJSONPath, uploadsExtractedPath)
+			if err != nil {
 				return c.Status(fiber.StatusInternalServerError).SendString("Error importing database data: " + err.Error())
 			}
 		case legacyDBPath != "":
@@ -1342,7 +1348,8 @@ func main() {
 			if err != nil {
 				return c.Status(fiber.StatusInternalServerError).SendString("Error reading legacy backup: " + err.Error())
 			}
-			if _, err := database.ImportFromJSON(db, payload, uploadsExtractedPath); err != nil {
+			importResult, err = database.ImportFromJSON(db, payload, uploadsExtractedPath)
+			if err != nil {
 				return c.Status(fiber.StatusInternalServerError).SendString("Error importing database data: " + err.Error())
 			}
 		default:
@@ -1350,9 +1357,11 @@ func main() {
 		}
 
 		if err := database.ImportUploads(uploadsExtractedPath); err != nil {
+			database.FailImport(db, importResult.ImportID, err.Error())
 			return c.Status(fiber.StatusInternalServerError).SendString("Error importing uploaded files: " + err.Error())
 		}
 
+		database.CompleteImport(db, importResult.ImportID)
 		return c.SendString("Backup import completed successfully")
 	})
 

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"archive/zip"
-	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -203,47 +202,13 @@ func main() {
 	app.Use(requestLogger(logWriter))
 
 	// Import-lock middleware — blocks all non-critical API calls during backup import
-	app.Use(func(c fiber.Ctx) error {
-		if importing.Load() && strings.HasPrefix(c.Path(), "/api/") {
-			if c.Path() != "/api/health" && c.Path() != "/api/backup/import" {
-				return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
-					"status":  "busy",
-					"message": "Server is restoring a backup. Please wait...",
-				})
-			}
-		}
-		return c.Next()
-	})
+	app.Use(ImportLockMiddleware(&importing))
 
 	// API routes grouped under /api
 	api := app.Group("/api")
 
 	// Health endpoint
-	api.Get("/health", func(c fiber.Ctx) error {
-		// Check DB connectivity
-		dbSQL, err := db.DB()
-		dbStatus := "ok"
-		if err != nil {
-			dbStatus = "error: " + err.Error()
-		} else if err := dbSQL.Ping(); err != nil {
-			dbStatus = "error: " + err.Error()
-		}
-
-		status := fiber.Map{
-			"status":     "ok",
-			"version":    version.Version,
-			"db":         dbStatus,
-			"demo":       demoMode,
-			"importing":  importing.Load(),
-		}
-
-		// If DB is not ok, return 500
-		if dbStatus != "ok" {
-			return c.Status(fiber.StatusInternalServerError).JSON(status)
-		}
-
-		return c.Status(fiber.StatusOK).JSON(status)
-	})
+	api.Get("/health", HealthHandler(db, demoMode, &importing))
 
 	// Get all appliances
 	api.Get("/appliances", func(c fiber.Ctx) error {
@@ -1282,189 +1247,7 @@ func main() {
 	})
 
 	// Import a backup ZIP — replaces all data: drop tables → migrate → insert
-	api.Post("/backup/import", func(c fiber.Ctx) error {
-		backupMu.Lock()
-		defer backupMu.Unlock()
-
-		importing.Store(true)
-		defer importing.Store(false)
-
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
-
-		file, err := c.FormFile("backup")
-		if err != nil {
-			return c.Status(fiber.StatusBadRequest).SendString("Error getting backup file: " + err.Error())
-		}
-
-		tempDir, err := os.MkdirTemp("", "homelogger-backup-import-")
-		if err != nil {
-			return c.Status(fiber.StatusInternalServerError).SendString("Error creating temp directory: " + err.Error())
-		}
-		defer func() { _ = os.RemoveAll(tempDir) }()
-
-		tempZipPath := filepath.Join(tempDir, file.Filename)
-		if err := c.SaveFile(file, tempZipPath); err != nil {
-			return c.Status(fiber.StatusInternalServerError).SendString("Error saving uploaded file: " + err.Error())
-		}
-
-		r, err := zip.OpenReader(tempZipPath)
-		if err != nil {
-			return c.Status(fiber.StatusInternalServerError).SendString("Error opening zip file: " + err.Error())
-		}
-		defer func() { _ = r.Close() }()
-
-		extractedPath := filepath.Join(tempDir, "extracted")
-		if err := os.MkdirAll(extractedPath, 0755); err != nil {
-			return c.Status(fiber.StatusInternalServerError).SendString("Error creating extraction directory: " + err.Error())
-		}
-
-		var dataJSONPath string
-		var legacyDBPath string
-		var uploadsExtractedPath string
-		var nestedDataJSON string
-		var nestedLegacyDB string
-		var nestedUploads string
-
-		for _, f := range r.File {
-			if err := ctx.Err(); err != nil {
-				return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
-					"status": "failed",
-					"error":  "Import timed out during ZIP extraction",
-				})
-			}
-			fpath := filepath.Join(extractedPath, f.Name)
-			if !strings.HasPrefix(fpath, filepath.Clean(extractedPath)+string(os.PathSeparator)) {
-				return c.Status(fiber.StatusBadRequest).SendString("Illegal file path in zip: " + fpath)
-			}
-			if f.FileInfo().IsDir() {
-				_ = os.MkdirAll(fpath, os.ModePerm)
-				continue
-			}
-			if err = os.MkdirAll(filepath.Dir(fpath), os.ModePerm); err != nil {
-				return c.Status(fiber.StatusInternalServerError).SendString("Error creating dir: " + err.Error())
-			}
-			outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
-			if err != nil {
-				return c.Status(fiber.StatusInternalServerError).SendString("Error creating file: " + err.Error())
-			}
-			rc, err := f.Open()
-			if err != nil {
-				_ = outFile.Close()
-				return c.Status(fiber.StatusInternalServerError).SendString("Error opening zip entry: " + err.Error())
-			}
-			_, copyErr := io.Copy(outFile, rc)
-			_ = outFile.Close()
-			_ = rc.Close()
-			if copyErr != nil {
-				return c.Status(fiber.StatusInternalServerError).SendString("Error extracting file: " + copyErr.Error())
-			}
-			switch {
-			case f.Name == "data.json":
-				dataJSONPath = fpath
-			case strings.HasSuffix(f.Name, "/data.json") && nestedDataJSON == "":
-				nestedDataJSON = f.Name
-			}
-			if strings.HasPrefix(f.Name, "db/") && strings.HasSuffix(strings.ToLower(f.Name), ".db") && legacyDBPath == "" {
-				legacyDBPath = fpath
-			} else if strings.Contains(f.Name, "/db/") && strings.HasSuffix(strings.ToLower(f.Name), ".db") && nestedLegacyDB == "" {
-				nestedLegacyDB = f.Name
-			}
-			if strings.HasPrefix(f.Name, "uploads/") && uploadsExtractedPath == "" {
-				uploadsExtractedPath = filepath.Join(extractedPath, "uploads")
-			} else if strings.Contains(f.Name, "/uploads/") && nestedUploads == "" {
-				nestedUploads = f.Name
-			}
-		}
-
-		if err := ctx.Err(); err != nil {
-			return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
-				"status": "failed",
-				"error":  "Import timed out before database import",
-			})
-		}
-
-		if dataJSONPath == "" && nestedDataJSON != "" {
-			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-				"status": "failed",
-				"error":  fmt.Sprintf("data.json was found inside %q — place it at the root of the ZIP archive", nestedDataJSON),
-			})
-		}
-		if dataJSONPath != "" && uploadsExtractedPath == "" && nestedUploads != "" {
-			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-				"status": "failed",
-				"error":  fmt.Sprintf("uploads folder was found inside %q — place uploads/ at the root of the ZIP archive", nestedUploads),
-			})
-		}
-
-		dbCtx := db.WithContext(ctx)
-		var importResult *models.ImportResult
-		switch {
-		case dataJSONPath != "":
-			importResult, err = database.ImportFromJSONFile(dbCtx, dataJSONPath, uploadsExtractedPath)
-			if err != nil {
-				return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-					"status":   "failed",
-					"importId": importResult.GetImportID(),
-					"error":    "Error importing database data: " + err.Error(),
-				})
-			}
-		case legacyDBPath != "":
-			payload, err := database.ConvertLegacyDB(legacyDBPath)
-			if err != nil {
-				return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-					"status": "failed",
-					"error":  "Error reading legacy backup: " + err.Error(),
-				})
-			}
-			importResult, err = database.ImportFromJSON(dbCtx, payload, uploadsExtractedPath)
-			if err != nil {
-				return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-					"status":   "failed",
-					"importId": importResult.GetImportID(),
-					"error":    "Error importing database data: " + err.Error(),
-				})
-			}
-		default:
-			msg := "Backup ZIP must contain data.json (new format) or a .db file in a db/ directory (legacy format)"
-			switch {
-			case nestedDataJSON != "":
-				msg += fmt.Sprintf(" data.json was found inside %q — place it at the root of the ZIP", nestedDataJSON)
-			case nestedLegacyDB != "":
-				msg += fmt.Sprintf(" legacy database was found inside %q — place it at the root of the ZIP", nestedLegacyDB)
-			}
-			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-				"status": "failed",
-				"error":  msg,
-			})
-		}
-
-		if err := ctx.Err(); err != nil {
-			database.FailImport(db, importResult.ImportID, "import timed out after database import")
-			return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
-				"status":   "failed",
-				"importId": importResult.ImportID,
-				"error":    "Import timed out after database import — uploads were not restored",
-			})
-		}
-
-		if err := database.ImportUploads(uploadsExtractedPath); err != nil {
-			database.FailImport(db, importResult.ImportID, err.Error())
-			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-				"status":   "failed",
-				"importId": importResult.ImportID,
-				"inserted": importResult.Inserted,
-				"error":    "Error importing uploaded files: " + err.Error(),
-			})
-		}
-
-		database.CompleteImport(db, importResult.ImportID)
-		return c.JSON(fiber.Map{
-			"status":   "completed",
-			"importId": importResult.ImportID,
-			"inserted": importResult.Inserted,
-		})
-	})
+	api.Post("/backup/import", ImportBackupHandler(db, &importing, &backupMu))
 
 	// Serve static SPA files with client-side routing fallback
 	app.Get("/*", static.New("./static"), func(c fiber.Ctx) error {

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -1322,6 +1322,9 @@ func main() {
 		var dataJSONPath string
 		var legacyDBPath string
 		var uploadsExtractedPath string
+		var nestedDataJSON string
+		var nestedLegacyDB string
+		var nestedUploads string
 
 		for _, f := range r.File {
 			if err := ctx.Err(); err != nil {
@@ -1356,12 +1359,21 @@ func main() {
 			if copyErr != nil {
 				return c.Status(fiber.StatusInternalServerError).SendString("Error extracting file: " + copyErr.Error())
 			}
-			if strings.EqualFold(filepath.Base(fpath), "data.json") {
+			switch {
+			case f.Name == "data.json":
 				dataJSONPath = fpath
-			} else if strings.HasPrefix(f.Name, "db/") && strings.HasSuffix(strings.ToLower(f.Name), ".db") && legacyDBPath == "" {
+			case strings.HasSuffix(f.Name, "/data.json") && nestedDataJSON == "":
+				nestedDataJSON = f.Name
+			}
+			if strings.HasPrefix(f.Name, "db/") && strings.HasSuffix(strings.ToLower(f.Name), ".db") && legacyDBPath == "" {
 				legacyDBPath = fpath
-			} else if strings.HasPrefix(f.Name, "uploads/") && uploadsExtractedPath == "" {
+			} else if strings.Contains(f.Name, "/db/") && strings.HasSuffix(strings.ToLower(f.Name), ".db") && nestedLegacyDB == "" {
+				nestedLegacyDB = f.Name
+			}
+			if strings.HasPrefix(f.Name, "uploads/") && uploadsExtractedPath == "" {
 				uploadsExtractedPath = filepath.Join(extractedPath, "uploads")
+			} else if strings.Contains(f.Name, "/uploads/") && nestedUploads == "" {
+				nestedUploads = f.Name
 			}
 		}
 
@@ -1369,6 +1381,19 @@ func main() {
 			return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
 				"status": "failed",
 				"error":  "Import timed out before database import",
+			})
+		}
+
+		if dataJSONPath == "" && nestedDataJSON != "" {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"status": "failed",
+				"error":  fmt.Sprintf("data.json was found inside %q — place it at the root of the ZIP archive", nestedDataJSON),
+			})
+		}
+		if dataJSONPath != "" && uploadsExtractedPath == "" && nestedUploads != "" {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"status": "failed",
+				"error":  fmt.Sprintf("uploads folder was found inside %q — place uploads/ at the root of the ZIP archive", nestedUploads),
 			})
 		}
 
@@ -1401,9 +1426,16 @@ func main() {
 				})
 			}
 		default:
+			msg := "Backup ZIP must contain data.json (new format) or a .db file in a db/ directory (legacy format)"
+			switch {
+			case nestedDataJSON != "":
+				msg += fmt.Sprintf(" data.json was found inside %q — place it at the root of the ZIP", nestedDataJSON)
+			case nestedLegacyDB != "":
+				msg += fmt.Sprintf(" legacy database was found inside %q — place it at the root of the ZIP", nestedLegacyDB)
+			}
 			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 				"status": "failed",
-				"error":  "Backup ZIP must contain data.json (new format) or a .db file in a db/ directory (legacy format)",
+				"error":  msg,
 			})
 		}
 

--- a/server/cmd/server/middleware.go
+++ b/server/cmd/server/middleware.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/gofiber/fiber/v3"
@@ -90,5 +91,19 @@ func requestLogger(w io.Writer) fiber.Handler {
 		)
 
 		return chainErr
+	}
+}
+
+func ImportLockMiddleware(importing *atomic.Bool) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		if importing.Load() && strings.HasPrefix(c.Path(), "/api/") {
+			if c.Path() != "/api/health" && c.Path() != "/api/backup/import" {
+				return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+					"status":  "busy",
+					"message": "Server is restoring a backup. Please wait...",
+				})
+			}
+		}
+		return c.Next()
 	}
 }

--- a/server/cmd/server/middleware_test.go
+++ b/server/cmd/server/middleware_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+)
+
+func TestImportLockMiddleware(t *testing.T) {
+	t.Run("not importing passes through", func(t *testing.T) {
+		var importing atomic.Bool
+		app := fiber.New()
+		app.Use(ImportLockMiddleware(&importing))
+
+		app.Get("/api/appliances", func(c fiber.Ctx) error {
+			return c.SendString("ok")
+		})
+
+		req := httptest.NewRequest("GET", "/api/appliances", nil)
+		resp, _ := app.Test(req)
+		if resp.StatusCode != fiber.StatusOK {
+			t.Errorf("expected 200, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("importing blocks non-critical routes", func(t *testing.T) {
+		var importing atomic.Bool
+		importing.Store(true)
+		app := fiber.New()
+		app.Use(ImportLockMiddleware(&importing))
+
+		app.Get("/api/appliances", func(c fiber.Ctx) error {
+			return c.SendString("ok")
+		})
+
+		req := httptest.NewRequest("GET", "/api/appliances", nil)
+		resp, _ := app.Test(req)
+		if resp.StatusCode != fiber.StatusServiceUnavailable {
+			t.Errorf("expected 503, got %d", resp.StatusCode)
+		}
+
+		var body map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&body)
+		if body["status"] != "busy" {
+			t.Errorf("expected status 'busy', got %v", body["status"])
+		}
+	})
+
+	t.Run("health bypasses import lock", func(t *testing.T) {
+		var importing atomic.Bool
+		importing.Store(true)
+		app := fiber.New()
+		app.Use(ImportLockMiddleware(&importing))
+
+		app.Get("/api/health", func(c fiber.Ctx) error {
+			return c.SendString("healthy")
+		})
+
+		req := httptest.NewRequest("GET", "/api/health", nil)
+		resp, _ := app.Test(req)
+		if resp.StatusCode != fiber.StatusOK {
+			t.Errorf("expected 200, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("import endpoint bypasses lock", func(t *testing.T) {
+		var importing atomic.Bool
+		importing.Store(true)
+		app := fiber.New()
+		app.Use(ImportLockMiddleware(&importing))
+
+		app.Post("/api/backup/import", func(c fiber.Ctx) error {
+			return c.SendString("importing")
+		})
+
+		req := httptest.NewRequest("POST", "/api/backup/import", nil)
+		resp, _ := app.Test(req)
+		if resp.StatusCode == fiber.StatusServiceUnavailable {
+			t.Error("import endpoint should bypass the lock")
+		}
+	})
+
+	t.Run("non-api routes bypass lock", func(t *testing.T) {
+		var importing atomic.Bool
+		importing.Store(true)
+		app := fiber.New()
+		app.Use(ImportLockMiddleware(&importing))
+
+		app.Get("/", func(c fiber.Ctx) error {
+			return c.SendString("home")
+		})
+
+		req := httptest.NewRequest("GET", "/", nil)
+		resp, _ := app.Test(req)
+		if resp.StatusCode != fiber.StatusOK {
+			t.Errorf("expected 200, got %d", resp.StatusCode)
+		}
+	})
+}
+
+

--- a/server/internal/database/import.go
+++ b/server/internal/database/import.go
@@ -71,48 +71,68 @@ func resetPostgresSequences(db *gorm.DB) error {
 
 // ImportFromJSON replaces all DB data with the payload contents.
 // Steps: drop all tables → re-migrate → bulk insert from payload.
+// The critical path (drop → migrate → insert → reset sequences) is wrapped
+// in a database transaction so that any failure fully rolls back, preventing
+// a broken or empty database state.
 // uploadsDir is the directory containing extracted upload files (may be "").
 func ImportFromJSON(db *gorm.DB, payload *models.BackupPayload, uploadsDir string) (*models.ImportResult, error) {
 	result := &models.ImportResult{}
 
-	// 1. Drop all tables
-	if err := dropAllTables(db); err != nil {
-		return nil, fmt.Errorf("drop tables: %w", err)
-	}
+	err := db.Transaction(func(tx *gorm.DB) error {
+		// 1. Drop all tables
+		if err := dropAllTables(tx); err != nil {
+			return fmt.Errorf("drop tables: %w", err)
+		}
 
-	// 2. Re-create schema
-	if err := MigrateGorm(db); err != nil {
-		return nil, fmt.Errorf("re-migrate: %w", err)
-	}
+		// 2. Re-create schema
+		if err := MigrateGorm(tx); err != nil {
+			return fmt.Errorf("re-migrate: %w", err)
+		}
 
-	// 3. Insert in FK dependency order (parents before children)
-	// note: insert individually (not batch) so GORM handles mixed auto/explicit IDs correctly.
-	insertEach := func(name string, fn func(i int) error, count int) {
-		for i := 0; i < count; i++ {
-			if err := fn(i); err != nil {
-				result.Errors++
-				result.ErrorMessage += fmt.Sprintf("%s[%d]: %v; ", name, i, err)
-			} else {
+		// 3. Insert in FK dependency order (parents before children)
+		// note: insert individually (not batch) so GORM handles mixed auto/explicit IDs correctly.
+		insertEach := func(name string, fn func(i int) error, count int) error {
+			for i := 0; i < count; i++ {
+				if err := fn(i); err != nil {
+					return fmt.Errorf("%s[%d]: %w", name, i, err)
+				}
 				result.Inserted++
 			}
+			return nil
 		}
-	}
 
-	insertEach("Appliance", func(i int) error { return db.Create(&payload.Entities.Appliances[i]).Error }, len(payload.Entities.Appliances))
-	insertEach("Todo", func(i int) error { return db.Create(&payload.Entities.Todos[i]).Error }, len(payload.Entities.Todos))
-	insertEach("Maintenance", func(i int) error { return db.Create(&payload.Entities.Maintenance[i]).Error }, len(payload.Entities.Maintenance))
-	insertEach("Repair", func(i int) error { return db.Create(&payload.Entities.Repairs[i]).Error }, len(payload.Entities.Repairs))
-	insertEach("SavedFile", func(i int) error { return db.Create(&payload.Entities.SavedFiles[i]).Error }, len(payload.Entities.SavedFiles))
-	insertEach("Note", func(i int) error { return db.Create(&payload.Entities.Notes[i]).Error }, len(payload.Entities.Notes))
-	insertEach("Task", func(i int) error { return db.Create(&payload.Entities.Tasks[i]).Error }, len(payload.Entities.Tasks))
+		if err := insertEach("Appliance", func(i int) error { return tx.Create(&payload.Entities.Appliances[i]).Error }, len(payload.Entities.Appliances)); err != nil {
+			return err
+		}
+		if err := insertEach("Todo", func(i int) error { return tx.Create(&payload.Entities.Todos[i]).Error }, len(payload.Entities.Todos)); err != nil {
+			return err
+		}
+		if err := insertEach("Maintenance", func(i int) error { return tx.Create(&payload.Entities.Maintenance[i]).Error }, len(payload.Entities.Maintenance)); err != nil {
+			return err
+		}
+		if err := insertEach("Repair", func(i int) error { return tx.Create(&payload.Entities.Repairs[i]).Error }, len(payload.Entities.Repairs)); err != nil {
+			return err
+		}
+		if err := insertEach("SavedFile", func(i int) error { return tx.Create(&payload.Entities.SavedFiles[i]).Error }, len(payload.Entities.SavedFiles)); err != nil {
+			return err
+		}
+		if err := insertEach("Note", func(i int) error { return tx.Create(&payload.Entities.Notes[i]).Error }, len(payload.Entities.Notes)); err != nil {
+			return err
+		}
+		if err := insertEach("Task", func(i int) error { return tx.Create(&payload.Entities.Tasks[i]).Error }, len(payload.Entities.Tasks)); err != nil {
+			return err
+		}
 
-	if result.Errors > 0 {
-		return result, fmt.Errorf("import errors: %s", result.ErrorMessage)
-	}
+		// 4. Resync Postgres sequences — inserting explicit IDs doesn't advance them
+		if err := resetPostgresSequences(tx); err != nil {
+			return fmt.Errorf("reset sequences: %w", err)
+		}
 
-	// 4. Resync Postgres sequences — inserting explicit IDs doesn't advance them
-	if err := resetPostgresSequences(db); err != nil {
-		return result, fmt.Errorf("reset sequences: %w", err)
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
 	}
 
 	// 5. Ensure todo→task migration tracking table exists, then handle migration.
@@ -156,22 +176,27 @@ func ImportFromJSONFile(db *gorm.DB, jsonFilePath string, uploadsDir string) (*m
 	return ImportFromJSON(db, &payload, uploadsDir)
 }
 
-// ImportUploads wipes the uploads directory and copies files from extractedUploadsPath.
+// ImportUploads replaces the uploads directory with files from extractedUploadsPath.
+// Files are staged in a temp directory first, then atomically swapped into place
+// so that a partial copy failure does not wipe the existing uploads.
 func ImportUploads(extractedUploadsPath string) error {
 	appUploadsRoot := "./data/uploads"
 
-	if err := os.RemoveAll(appUploadsRoot); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("remove uploads: %w", err)
-	}
-	if err := os.MkdirAll(appUploadsRoot, 0755); err != nil {
-		return fmt.Errorf("mkdir uploads: %w", err)
-	}
-
 	if extractedUploadsPath == "" {
-		return nil // no uploads in backup, that's fine
+		return nil
 	}
 
-	return filepath.Walk(extractedUploadsPath, func(path string, info os.FileInfo, err error) error {
+	tempDir, err := os.MkdirTemp("", "homelogger-uploads-import-")
+	if err != nil {
+		return fmt.Errorf("create temp dir: %w", err)
+	}
+	defer func() {
+		if tempDir != "" {
+			os.RemoveAll(tempDir)
+		}
+	}()
+
+	err = filepath.Walk(extractedUploadsPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() {
 			return err
 		}
@@ -181,7 +206,7 @@ func ImportUploads(extractedUploadsPath string) error {
 			return err
 		}
 
-		dest := filepath.Join(appUploadsRoot, rel)
+		dest := filepath.Join(tempDir, rel)
 		if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
 			return err
 		}
@@ -201,4 +226,19 @@ func ImportUploads(extractedUploadsPath string) error {
 		_, err = io.Copy(dst, src)
 		return err
 	})
+	if err != nil {
+		return fmt.Errorf("stage uploads: %w", err)
+	}
+
+	if err := os.RemoveAll(appUploadsRoot); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove old uploads: %w", err)
+	}
+
+	if err := os.Rename(tempDir, appUploadsRoot); err != nil {
+		os.MkdirAll(appUploadsRoot, 0755)
+		return fmt.Errorf("swap uploads: %w", err)
+	}
+
+	tempDir = ""
+	return nil
 }

--- a/server/internal/database/import.go
+++ b/server/internal/database/import.go
@@ -125,6 +125,142 @@ func CheckImportLog(db *gorm.DB) string {
 	return msg
 }
 
+// validatePayload checks basic structural and required-field constraints on the
+// backup payload, before any destructive DB operations begin.
+// Returns the first error found — fail-fast.
+func validatePayload(payload *models.BackupPayload) error {
+	if payload.Version == "" {
+		return fmt.Errorf("backup version is required")
+	}
+	if payload.DatabaseType == "" {
+		return fmt.Errorf("database type is required")
+	}
+
+	seenIDs := make(map[uint]bool)
+
+	for i, e := range payload.Entities.Appliances {
+		if e.ApplianceName == "" {
+			return fmt.Errorf("appliance[%d].applianceName: must not be empty", i)
+		}
+		if e.Manufacturer == "" {
+			return fmt.Errorf("appliance[%d].manufacturer: must not be empty", i)
+		}
+		if e.ModelNumber == "" {
+			return fmt.Errorf("appliance[%d].modelNumber: must not be empty", i)
+		}
+		if e.SerialNumber == "" {
+			return fmt.Errorf("appliance[%d].serialNumber: must not be empty", i)
+		}
+		if e.YearPurchased == "" {
+			return fmt.Errorf("appliance[%d].yearPurchased: must not be empty", i)
+		}
+		if e.PurchasePrice == "" {
+			return fmt.Errorf("appliance[%d].purchasePrice: must not be empty", i)
+		}
+		if e.Location == "" {
+			return fmt.Errorf("appliance[%d].location: must not be empty", i)
+		}
+		if e.Type == "" {
+			return fmt.Errorf("appliance[%d].type: must not be empty", i)
+		}
+		if e.ID != 0 {
+			if seenIDs[e.ID] {
+				return fmt.Errorf("duplicate appliance ID: %d", e.ID)
+			}
+			seenIDs[e.ID] = true
+		}
+	}
+
+	seenIDs = make(map[uint]bool)
+	for i, e := range payload.Entities.Todos {
+		if e.UserID == "" {
+			return fmt.Errorf("todo[%d].userid: must not be empty", i)
+		}
+		if e.ID != 0 {
+			if seenIDs[e.ID] {
+				return fmt.Errorf("duplicate todo ID: %d", e.ID)
+			}
+			seenIDs[e.ID] = true
+		}
+	}
+
+	seenIDs = make(map[uint]bool)
+	for i, e := range payload.Entities.Maintenance {
+		if e.Description == "" {
+			return fmt.Errorf("maintenance[%d].description: must not be empty", i)
+		}
+		if e.Date == "" {
+			return fmt.Errorf("maintenance[%d].date: must not be empty", i)
+		}
+		if e.ID != 0 {
+			if seenIDs[e.ID] {
+				return fmt.Errorf("duplicate maintenance ID: %d", e.ID)
+			}
+			seenIDs[e.ID] = true
+		}
+	}
+
+	seenIDs = make(map[uint]bool)
+	for i, e := range payload.Entities.Repairs {
+		if e.Description == "" {
+			return fmt.Errorf("repair[%d].description: must not be empty", i)
+		}
+		if e.Date == "" {
+			return fmt.Errorf("repair[%d].date: must not be empty", i)
+		}
+		if e.ID != 0 {
+			if seenIDs[e.ID] {
+				return fmt.Errorf("duplicate repair ID: %d", e.ID)
+			}
+			seenIDs[e.ID] = true
+		}
+	}
+
+	seenIDs = make(map[uint]bool)
+	for i, e := range payload.Entities.SavedFiles {
+		if e.Path == "" {
+			return fmt.Errorf("savedFile[%d].path: must not be empty", i)
+		}
+		if e.OriginalName == "" {
+			return fmt.Errorf("savedFile[%d].originalName: must not be empty", i)
+		}
+		if e.Type == "" {
+			return fmt.Errorf("savedFile[%d].type: must not be empty", i)
+		}
+		if e.UserID == "" {
+			return fmt.Errorf("savedFile[%d].userid: must not be empty", i)
+		}
+		if e.ID != 0 {
+			if seenIDs[e.ID] {
+				return fmt.Errorf("duplicate savedFile ID: %d", e.ID)
+			}
+			seenIDs[e.ID] = true
+		}
+	}
+
+	seenIDs = make(map[uint]bool)
+	for i := range payload.Entities.Notes {
+		if payload.Entities.Notes[i].ID != 0 {
+			if seenIDs[payload.Entities.Notes[i].ID] {
+				return fmt.Errorf("duplicate note ID: %d", payload.Entities.Notes[i].ID)
+			}
+			seenIDs[payload.Entities.Notes[i].ID] = true
+		}
+	}
+
+	seenIDs = make(map[uint]bool)
+	for i := range payload.Entities.Tasks {
+		if payload.Entities.Tasks[i].ID != 0 {
+			if seenIDs[payload.Entities.Tasks[i].ID] {
+				return fmt.Errorf("duplicate task ID: %d", payload.Entities.Tasks[i].ID)
+			}
+			seenIDs[payload.Entities.Tasks[i].ID] = true
+		}
+	}
+
+	return nil
+}
+
 // ImportFromJSON replaces all DB data with the payload contents.
 // Steps: drop all tables → re-migrate → bulk insert from payload.
 // The critical path (drop → migrate → insert → reset sequences) is wrapped
@@ -139,6 +275,10 @@ func ImportFromJSON(db *gorm.DB, payload *models.BackupPayload, uploadsDir strin
 	}
 
 	sanitizeFKs(payload)
+
+	if err := validatePayload(payload); err != nil {
+		return nil, fmt.Errorf("invalid backup: %w", err)
+	}
 
 	importID := fmt.Sprintf("imp_%d", time.Now().UnixNano())
 	result.ImportID = importID

--- a/server/internal/database/import.go
+++ b/server/internal/database/import.go
@@ -142,27 +142,6 @@ func validatePayload(payload *models.BackupPayload) error {
 		if e.ApplianceName == "" {
 			return fmt.Errorf("appliance[%d].applianceName: must not be empty", i)
 		}
-		if e.Manufacturer == "" {
-			return fmt.Errorf("appliance[%d].manufacturer: must not be empty", i)
-		}
-		if e.ModelNumber == "" {
-			return fmt.Errorf("appliance[%d].modelNumber: must not be empty", i)
-		}
-		if e.SerialNumber == "" {
-			return fmt.Errorf("appliance[%d].serialNumber: must not be empty", i)
-		}
-		if e.YearPurchased == "" {
-			return fmt.Errorf("appliance[%d].yearPurchased: must not be empty", i)
-		}
-		if e.PurchasePrice == "" {
-			return fmt.Errorf("appliance[%d].purchasePrice: must not be empty", i)
-		}
-		if e.Location == "" {
-			return fmt.Errorf("appliance[%d].location: must not be empty", i)
-		}
-		if e.Type == "" {
-			return fmt.Errorf("appliance[%d].type: must not be empty", i)
-		}
 		if e.ID != 0 {
 			if seenIDs[e.ID] {
 				return fmt.Errorf("duplicate appliance ID: %d", e.ID)
@@ -223,9 +202,6 @@ func validatePayload(payload *models.BackupPayload) error {
 		}
 		if e.OriginalName == "" {
 			return fmt.Errorf("savedFile[%d].originalName: must not be empty", i)
-		}
-		if e.Type == "" {
-			return fmt.Errorf("savedFile[%d].type: must not be empty", i)
 		}
 		if e.UserID == "" {
 			return fmt.Errorf("savedFile[%d].userid: must not be empty", i)

--- a/server/internal/database/import.go
+++ b/server/internal/database/import.go
@@ -306,15 +306,33 @@ func ImportUploads(extractedUploadsPath string) error {
 		return fmt.Errorf("stage uploads: %w", err)
 	}
 
-	if err := os.RemoveAll(appUploadsRoot); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("remove old uploads: %w", err)
+	// Backup old uploads by renaming out of the way.
+	// This keeps the original data intact in case the swap fails.
+	oldBackup := appUploadsRoot + ".bak"
+	if err := os.RemoveAll(oldBackup); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("clean stale backup: %w", err)
+	}
+
+	if err := os.Rename(appUploadsRoot, oldBackup); err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("backup old uploads: %w", err)
+		}
+		// No existing uploads directory — that's fine.
+		oldBackup = ""
 	}
 
 	if err := os.Rename(tempDir, appUploadsRoot); err != nil {
-		os.MkdirAll(appUploadsRoot, 0755)
+		// Swap failed — restore original uploads if we backed them up.
+		if oldBackup != "" {
+			_ = os.Rename(oldBackup, appUploadsRoot)
+		}
 		return fmt.Errorf("swap uploads: %w", err)
 	}
 
+	// Success — clean up old backup and mark temp as handled.
+	if oldBackup != "" {
+		_ = os.RemoveAll(oldBackup)
+	}
 	tempDir = ""
 	return nil
 }

--- a/server/internal/database/import.go
+++ b/server/internal/database/import.go
@@ -237,6 +237,32 @@ func validatePayload(payload *models.BackupPayload) error {
 	return nil
 }
 
+// validateUploads checks that every SavedFile referenced in the payload has a
+// corresponding file in the extracted uploads directory. Returns the first
+// missing file as an error. Skips validation if uploadsDir is empty.
+func validateUploads(payload *models.BackupPayload, uploadsDir string) error {
+	if uploadsDir == "" {
+		return nil
+	}
+	for i, f := range payload.Entities.SavedFiles {
+		if f.Path == "" {
+			continue
+		}
+		rel, err := filepath.Rel("./data/uploads", f.Path)
+		if err != nil {
+			rel = filepath.Base(f.Path)
+		}
+		expected := filepath.Join(uploadsDir, rel)
+		if _, err := os.Stat(expected); err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("savedFile[%d] references file %q but it was not found in the backup uploads", i, rel)
+			}
+			return fmt.Errorf("savedFile[%d]: %w", i, err)
+		}
+	}
+	return nil
+}
+
 // ImportFromJSON replaces all DB data with the payload contents.
 // Steps: drop all tables → re-migrate → bulk insert from payload.
 // The critical path (drop → migrate → insert → reset sequences) is wrapped
@@ -253,6 +279,10 @@ func ImportFromJSON(db *gorm.DB, payload *models.BackupPayload, uploadsDir strin
 	sanitizeFKs(payload)
 
 	if err := validatePayload(payload); err != nil {
+		return nil, fmt.Errorf("invalid backup: %w", err)
+	}
+
+	if err := validateUploads(payload, uploadsDir); err != nil {
 		return nil, fmt.Errorf("invalid backup: %w", err)
 	}
 

--- a/server/internal/database/import.go
+++ b/server/internal/database/import.go
@@ -129,6 +129,9 @@ func CheckImportLog(db *gorm.DB) string {
 // backup payload, before any destructive DB operations begin.
 // Returns the first error found — fail-fast.
 func validatePayload(payload *models.BackupPayload) error {
+	if payload == nil {
+		return fmt.Errorf("backup payload is nil")
+	}
 	if payload.Version == "" {
 		return fmt.Errorf("backup version is required")
 	}
@@ -276,7 +279,7 @@ func ImportFromJSON(db *gorm.DB, payload *models.BackupPayload, uploadsDir strin
 		return nil, fmt.Errorf("ensure import_log: %w", err)
 	}
 
-	sanitizeFKs(payload)
+	SanitizeFKs(payload)
 
 	if err := validatePayload(payload); err != nil {
 		return nil, fmt.Errorf("invalid backup: %w", err)

--- a/server/internal/database/import.go
+++ b/server/internal/database/import.go
@@ -202,34 +202,36 @@ func ImportFromJSON(db *gorm.DB, payload *models.BackupPayload, uploadsDir strin
 			return fmt.Errorf("record import state: %w", err)
 		}
 
+		// 6. Ensure todo→task migration tracking table and migrate.
+		// Runs inside the transaction so that any failure rolls back the entire import.
+		if len(payload.Entities.Todos) > 0 {
+			if err := tx.Exec(`CREATE TABLE IF NOT EXISTS todo_task_migrations (todo_id BIGINT PRIMARY KEY)`).Error; err != nil {
+				return fmt.Errorf("create migration tracking table: %w", err)
+			}
+			// If both todos and tasks were imported, mark all todos as already
+			// migrated so MigrateTodosToTasks doesn't create duplicates.
+			if len(payload.Entities.Tasks) > 0 {
+				insertSQL := "INSERT OR IGNORE INTO todo_task_migrations (todo_id) VALUES (?)"
+				if tx.Dialector.Name() == dialectPostgres {
+					insertSQL = "INSERT INTO todo_task_migrations (todo_id) VALUES (?) ON CONFLICT (todo_id) DO NOTHING"
+				}
+				for _, todo := range payload.Entities.Todos {
+					if err := tx.Exec(insertSQL, todo.ID).Error; err != nil {
+						return fmt.Errorf("track migration todo[%d]: %w", todo.ID, err)
+					}
+				}
+			}
+			// Migrate any remaining todos (those without a tracking entry) to tasks now.
+			if err := MigrateTodosToTasks(tx); err != nil {
+				return fmt.Errorf("migrate todos: %w", err)
+			}
+		}
+
 		return nil
 	})
 
 	if err != nil {
 		return nil, err
-	}
-
-	// 5. Ensure todo→task migration tracking table exists, then handle migration.
-	if err := db.Exec(`CREATE TABLE IF NOT EXISTS todo_task_migrations (todo_id BIGINT PRIMARY KEY)`).Error; err != nil {
-		result.ErrorMessage += fmt.Sprintf("create migration tracking table: %v; ", err)
-	} else if len(payload.Entities.Todos) > 0 {
-		// If both todos and tasks were imported, mark all todos as already
-		// migrated so MigrateTodosToTasks doesn't create duplicates.
-		if len(payload.Entities.Tasks) > 0 {
-			insertSQL := "INSERT OR IGNORE INTO todo_task_migrations (todo_id) VALUES (?)"
-			if db.Dialector.Name() == dialectPostgres {
-				insertSQL = "INSERT INTO todo_task_migrations (todo_id) VALUES (?) ON CONFLICT (todo_id) DO NOTHING"
-			}
-			for _, todo := range payload.Entities.Todos {
-				if err := db.Exec(insertSQL, todo.ID).Error; err != nil {
-					result.ErrorMessage += fmt.Sprintf("track migration todo[%d]: %v; ", todo.ID, err)
-				}
-			}
-		}
-		// Migrate any remaining todos (those without a tracking entry) to tasks now.
-		if err := MigrateTodosToTasks(db); err != nil {
-			result.ErrorMessage += fmt.Sprintf("migrate todos: %v; ", err)
-		}
 	}
 
 	return result, nil

--- a/server/internal/database/import.go
+++ b/server/internal/database/import.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/masoncfrancis/homelogger/server/internal/models"
 	"gorm.io/gorm"
@@ -69,6 +70,61 @@ func resetPostgresSequences(db *gorm.DB) error {
 	return nil
 }
 
+// importLogDDL creates the import_log tracking table.
+// Not in tableDropOrder — never dropped, persists across imports.
+// Used to detect interrupted imports on server restart.
+const importLogDDL = `CREATE TABLE IF NOT EXISTS import_log (
+    id           TEXT PRIMARY KEY,
+    status       TEXT NOT NULL DEFAULT 'in_progress',
+    error_msg    TEXT,
+    created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    completed_at TIMESTAMP
+)`
+
+func ensureImportLogTable(db *gorm.DB) error {
+	return db.Exec(importLogDDL).Error
+}
+
+// CompleteImport marks an import as completed after upload swap succeeds.
+// Best-effort — errors are logged but not returned (uploads already swapped).
+func CompleteImport(db *gorm.DB, importID string) {
+	if err := db.Exec("UPDATE import_log SET status = 'completed', completed_at = CURRENT_TIMESTAMP WHERE id = ?", importID).Error; err != nil {
+		fmt.Printf("Warning: failed to mark import %s as completed: %v\n", importID, err)
+	}
+}
+
+// FailImport marks an import as failed when upload swap errors out.
+func FailImport(db *gorm.DB, importID, reason string) {
+	if err := db.Exec("UPDATE import_log SET status = 'failed', error_msg = ? WHERE id = ?", reason, importID).Error; err != nil {
+		fmt.Printf("Warning: failed to mark import %s as failed: %v\n", importID, err)
+	}
+}
+
+// CheckImportLog checks for incomplete imports and returns a warning message
+// if any are found. Should be called at server startup after MigrateGorm.
+func CheckImportLog(db *gorm.DB) string {
+	if err := ensureImportLogTable(db); err != nil {
+		return fmt.Sprintf("Warning: could not ensure import_log table: %v", err)
+	}
+	type pendingImport struct {
+		ID        string
+		Status    string
+		CreatedAt time.Time `gorm:"column:created_at"`
+	}
+	var pending []pendingImport
+	if err := db.Table("import_log").Where("status NOT IN ('completed', 'failed')").Find(&pending).Error; err != nil {
+		return fmt.Sprintf("Warning: could not check import log: %v", err)
+	}
+	if len(pending) == 0 {
+		return ""
+	}
+	var msg string
+	for _, p := range pending {
+		msg += fmt.Sprintf("Import %s was interrupted (status: %s, started: %s). Re-run import to ensure data consistency.\n", p.ID, p.Status, p.CreatedAt.Format(time.RFC3339))
+	}
+	return msg
+}
+
 // ImportFromJSON replaces all DB data with the payload contents.
 // Steps: drop all tables → re-migrate → bulk insert from payload.
 // The critical path (drop → migrate → insert → reset sequences) is wrapped
@@ -77,6 +133,15 @@ func resetPostgresSequences(db *gorm.DB) error {
 // uploadsDir is the directory containing extracted upload files (may be "").
 func ImportFromJSON(db *gorm.DB, payload *models.BackupPayload, uploadsDir string) (*models.ImportResult, error) {
 	result := &models.ImportResult{}
+
+	if err := ensureImportLogTable(db); err != nil {
+		return nil, fmt.Errorf("ensure import_log: %w", err)
+	}
+
+	sanitizeFKs(payload)
+
+	importID := fmt.Sprintf("imp_%d", time.Now().UnixNano())
+	result.ImportID = importID
 
 	err := db.Transaction(func(tx *gorm.DB) error {
 		// 1. Drop all tables
@@ -126,6 +191,15 @@ func ImportFromJSON(db *gorm.DB, payload *models.BackupPayload, uploadsDir strin
 		// 4. Resync Postgres sequences — inserting explicit IDs doesn't advance them
 		if err := resetPostgresSequences(tx); err != nil {
 			return fmt.Errorf("reset sequences: %w", err)
+		}
+
+		// 5. Record in_progress in import_log for crash detection.
+		// Clear old entries first — only care about latest.
+		if err := tx.Exec("DELETE FROM import_log").Error; err != nil {
+			return fmt.Errorf("clear import_log: %w", err)
+		}
+		if err := tx.Exec("INSERT INTO import_log (id, status) VALUES (?, 'in_progress')", importID).Error; err != nil {
+			return fmt.Errorf("record import state: %w", err)
 		}
 
 		return nil
@@ -186,7 +260,7 @@ func ImportUploads(extractedUploadsPath string) error {
 		return nil
 	}
 
-	tempDir, err := os.MkdirTemp("", "homelogger-uploads-import-")
+	tempDir, err := os.MkdirTemp("./data", "uploads-import-")
 	if err != nil {
 		return fmt.Errorf("create temp dir: %w", err)
 	}

--- a/server/internal/database/import_log_test.go
+++ b/server/internal/database/import_log_test.go
@@ -1,0 +1,125 @@
+package database
+
+import (
+	"strings"
+	"testing"
+
+	"gorm.io/gorm"
+)
+
+func ensureImportLogTableForTest(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	if err := ensureImportLogTable(db); err != nil {
+		t.Fatalf("failed to create import_log table: %v", err)
+	}
+}
+
+func TestCompleteImport(t *testing.T) {
+	db := TestDB(t)
+
+	ensureImportLogTableForTest(t, db)
+
+	importID := "test-complete-001"
+	if err := db.Exec("INSERT INTO import_log (id, status) VALUES (?, 'in_progress')", importID).Error; err != nil {
+		t.Fatalf("failed to insert test row: %v", err)
+	}
+
+	CompleteImport(db, importID)
+
+	type importLogRow struct {
+		ID     string
+		Status string
+	}
+	var row importLogRow
+	if err := db.Table("import_log").Where("id = ?", importID).First(&row).Error; err != nil {
+		t.Fatalf("failed to query import_log: %v", err)
+	}
+
+	if row.Status != "completed" {
+		t.Errorf("expected status 'completed', got %q", row.Status)
+	}
+
+	var count int64
+	db.Table("import_log").Where("id = ? AND completed_at IS NOT NULL", importID).Count(&count)
+	if count == 0 {
+		t.Error("expected completed_at to be set, but it IS NULL")
+	}
+}
+
+func TestFailImport(t *testing.T) {
+	db := TestDB(t)
+
+	ensureImportLogTableForTest(t, db)
+
+	importID := "test-fail-001"
+	if err := db.Exec("INSERT INTO import_log (id, status) VALUES (?, 'in_progress')", importID).Error; err != nil {
+		t.Fatalf("failed to insert test row: %v", err)
+	}
+
+	reason := "deliberate test failure"
+	FailImport(db, importID, reason)
+
+	type importLogRow struct {
+		ID       string
+		Status   string
+		ErrorMsg *string `gorm:"column:error_msg"`
+	}
+	var row importLogRow
+	if err := db.Table("import_log").Where("id = ?", importID).First(&row).Error; err != nil {
+		t.Fatalf("failed to query import_log: %v", err)
+	}
+
+	if row.Status != "failed" {
+		t.Errorf("expected status 'failed', got %q", row.Status)
+	}
+	if row.ErrorMsg == nil {
+		t.Fatal("expected error_msg to be set, got nil")
+	}
+	if *row.ErrorMsg != reason {
+		t.Errorf("expected error_msg %q, got %q", reason, *row.ErrorMsg)
+	}
+}
+
+func TestCheckImportLog(t *testing.T) {
+	t.Run("empty log returns empty string", func(t *testing.T) {
+		db := TestDB(t)
+		msg := CheckImportLog(db)
+		if msg != "" {
+			t.Errorf("expected empty string, got %q", msg)
+		}
+	})
+
+	t.Run("all completed or failed returns empty", func(t *testing.T) {
+		db := TestDB(t)
+		ensureImportLogTableForTest(t, db)
+
+		if err := db.Exec("INSERT INTO import_log (id, status) VALUES ('c1', 'completed')").Error; err != nil {
+			t.Fatalf("failed to insert: %v", err)
+		}
+		if err := db.Exec("INSERT INTO import_log (id, status) VALUES ('f1', 'failed')").Error; err != nil {
+			t.Fatalf("failed to insert: %v", err)
+		}
+
+		msg := CheckImportLog(db)
+		if msg != "" {
+			t.Errorf("expected empty string, got %q", msg)
+		}
+	})
+
+	t.Run("stale in_progress returns warning", func(t *testing.T) {
+		db := TestDB(t)
+		ensureImportLogTableForTest(t, db)
+
+		if err := db.Exec("INSERT INTO import_log (id, status) VALUES ('stale-001', 'in_progress')").Error; err != nil {
+			t.Fatalf("failed to insert: %v", err)
+		}
+
+		msg := CheckImportLog(db)
+		if msg == "" {
+			t.Fatal("expected non-empty warning for in_progress import")
+		}
+		if msg != "" && !strings.Contains(msg, "stale-001") {
+			t.Errorf("expected warning to mention 'stale-001', got %q", msg)
+		}
+	})
+}

--- a/server/internal/database/import_uploads_test.go
+++ b/server/internal/database/import_uploads_test.go
@@ -1,0 +1,113 @@
+package database
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestImportUploads(t *testing.T) {
+	t.Run("empty path returns nil", func(t *testing.T) {
+		if err := ImportUploads(""); err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("successful swap replaces uploads", func(t *testing.T) {
+		origDir, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("getwd: %v", err)
+		}
+		testDir := t.TempDir()
+		if err := os.Chdir(testDir); err != nil {
+			t.Fatalf("chdir: %v", err)
+		}
+		defer os.Chdir(origDir)
+
+		stageDir := filepath.Join(testDir, "stage-uploads")
+		if err := os.MkdirAll(stageDir, 0755); err != nil {
+			t.Fatalf("mkdir stage: %v", err)
+		}
+
+		// Create a file in the stage dir
+		stageFile := filepath.Join(stageDir, "photo.jpg")
+		if err := os.WriteFile(stageFile, []byte("photo-data"), 0644); err != nil {
+			t.Fatalf("write stage file: %v", err)
+		}
+
+		// Create existing uploads with different content
+		oldUploads := "./data/uploads"
+		if err := os.MkdirAll(oldUploads, 0755); err != nil {
+			t.Fatalf("mkdir old uploads: %v", err)
+		}
+		oldFile := filepath.Join(oldUploads, "old-doc.txt")
+		if err := os.WriteFile(oldFile, []byte("old-data"), 0644); err != nil {
+			t.Fatalf("write old file: %v", err)
+		}
+
+		if err := ImportUploads(stageDir); err != nil {
+			t.Fatalf("ImportUploads failed: %v", err)
+		}
+
+		// Verify old file is gone
+		if _, err := os.Stat(oldFile); !os.IsNotExist(err) {
+			t.Error("expected old upload file to be removed")
+		}
+
+		// Verify new file is in place
+		newFile := filepath.Join(oldUploads, "photo.jpg")
+		data, err := os.ReadFile(newFile)
+		if err != nil {
+			t.Fatalf("read new file: %v", err)
+		}
+		if string(data) != "photo-data" {
+			t.Errorf("expected 'photo-data', got %q", string(data))
+		}
+
+		// Verify .bak was cleaned up
+		if _, err := os.Stat("./data/uploads.bak"); !os.IsNotExist(err) {
+			t.Error("expected .bak to be removed after successful swap")
+		}
+	})
+
+	t.Run("no existing uploads creates new directory", func(t *testing.T) {
+		origDir, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("getwd: %v", err)
+		}
+		testDir := t.TempDir()
+		if err := os.Chdir(testDir); err != nil {
+			t.Fatalf("chdir: %v", err)
+		}
+		defer os.Chdir(origDir)
+
+		// ImportUploads creates temp dir under ./data, so ./data must exist
+		if err := os.MkdirAll("./data", 0755); err != nil {
+			t.Fatalf("mkdir ./data: %v", err)
+		}
+
+		stageDir := filepath.Join(testDir, "stage-uploads")
+		if err := os.MkdirAll(stageDir, 0755); err != nil {
+			t.Fatalf("mkdir stage: %v", err)
+		}
+
+		stageFile := filepath.Join(stageDir, "doc.pdf")
+		if err := os.WriteFile(stageFile, []byte("pdf-data"), 0644); err != nil {
+			t.Fatalf("write stage file: %v", err)
+		}
+
+		if err := ImportUploads(stageDir); err != nil {
+			t.Fatalf("ImportUploads failed: %v", err)
+		}
+
+		// Verify the uploads directory was created
+		newFile := filepath.Join("./data/uploads", "doc.pdf")
+		data, err := os.ReadFile(newFile)
+		if err != nil {
+			t.Fatalf("read file: %v", err)
+		}
+		if string(data) != "pdf-data" {
+			t.Errorf("expected 'pdf-data', got %q", string(data))
+		}
+	})
+}

--- a/server/internal/database/import_validation_test.go
+++ b/server/internal/database/import_validation_test.go
@@ -1,0 +1,347 @@
+package database
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/masoncfrancis/homelogger/server/internal/models"
+)
+
+func validMinimalPayload() *models.BackupPayload {
+	return &models.BackupPayload{
+		Version:      BackupVersion,
+		DatabaseType: "sqlite",
+		Entities: models.Entities{
+			Appliances: []models.Appliance{
+				{ApplianceName: "Test Fridge"},
+			},
+			Maintenance: []models.Maintenance{
+				{Description: "Filter change", Date: "2026-01-15"},
+			},
+			Repairs: []models.Repair{
+				{Description: "Fix leak", Date: "2026-03-01"},
+			},
+			SavedFiles: []models.SavedFile{
+				{Path: "./data/uploads/1", OriginalName: "doc.pdf", UserID: "user1"},
+			},
+			Todos: []models.Todo{
+				{UserID: "user1"},
+			},
+		},
+	}
+}
+
+func TestValidatePayload(t *testing.T) {
+	t.Run("valid minimal payload", func(t *testing.T) {
+		err := validatePayload(validMinimalPayload())
+		if err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("nil payload", func(t *testing.T) {
+		err := validatePayload(nil)
+		if err == nil {
+			t.Fatal("expected error for nil payload")
+		}
+	})
+
+	t.Run("empty version", func(t *testing.T) {
+		p := validMinimalPayload()
+		p.Version = ""
+		err := validatePayload(p)
+		if err == nil {
+			t.Fatal("expected error for empty version")
+		}
+	})
+
+	t.Run("empty database type", func(t *testing.T) {
+		p := validMinimalPayload()
+		p.DatabaseType = ""
+		err := validatePayload(p)
+		if err == nil {
+			t.Fatal("expected error for empty database type")
+		}
+	})
+
+	t.Run("appliance missing name", func(t *testing.T) {
+		p := validMinimalPayload()
+		p.Entities.Appliances = append(p.Entities.Appliances, models.Appliance{})
+		err := validatePayload(p)
+		if err == nil {
+			t.Fatal("expected error for appliance with empty name")
+		}
+	})
+
+	t.Run("maintenance missing description", func(t *testing.T) {
+		p := validMinimalPayload()
+		p.Entities.Maintenance = append(p.Entities.Maintenance, models.Maintenance{Date: "2026-01-01"})
+		err := validatePayload(p)
+		if err == nil {
+			t.Fatal("expected error for maintenance with empty description")
+		}
+	})
+
+	t.Run("maintenance missing date", func(t *testing.T) {
+		p := validMinimalPayload()
+		p.Entities.Maintenance = append(p.Entities.Maintenance, models.Maintenance{Description: "Test"})
+		err := validatePayload(p)
+		if err == nil {
+			t.Fatal("expected error for maintenance with empty date")
+		}
+	})
+
+	t.Run("repair missing description", func(t *testing.T) {
+		p := validMinimalPayload()
+		p.Entities.Repairs = append(p.Entities.Repairs, models.Repair{Date: "2026-01-01"})
+		err := validatePayload(p)
+		if err == nil {
+			t.Fatal("expected error for repair with empty description")
+		}
+	})
+
+	t.Run("repair missing date", func(t *testing.T) {
+		p := validMinimalPayload()
+		p.Entities.Repairs = append(p.Entities.Repairs, models.Repair{Description: "Test"})
+		err := validatePayload(p)
+		if err == nil {
+			t.Fatal("expected error for repair with empty date")
+		}
+	})
+
+	t.Run("savedFile missing path", func(t *testing.T) {
+		p := validMinimalPayload()
+		p.Entities.SavedFiles = append(p.Entities.SavedFiles, models.SavedFile{OriginalName: "f", UserID: "u"})
+		err := validatePayload(p)
+		if err == nil {
+			t.Fatal("expected error for savedFile with empty path")
+		}
+	})
+
+	t.Run("savedFile missing originalName", func(t *testing.T) {
+		p := validMinimalPayload()
+		p.Entities.SavedFiles = append(p.Entities.SavedFiles, models.SavedFile{Path: "./p", UserID: "u"})
+		err := validatePayload(p)
+		if err == nil {
+			t.Fatal("expected error for savedFile with empty originalName")
+		}
+	})
+
+	t.Run("savedFile missing userid", func(t *testing.T) {
+		p := validMinimalPayload()
+		p.Entities.SavedFiles = append(p.Entities.SavedFiles, models.SavedFile{Path: "./p", OriginalName: "f"})
+		err := validatePayload(p)
+		if err == nil {
+			t.Fatal("expected error for savedFile with empty userid")
+		}
+	})
+
+	t.Run("todo missing userid", func(t *testing.T) {
+		p := validMinimalPayload()
+		p.Entities.Todos = append(p.Entities.Todos, models.Todo{})
+		err := validatePayload(p)
+		if err == nil {
+			t.Fatal("expected error for todo with empty userid")
+		}
+	})
+
+	t.Run("empty entities sections should pass", func(t *testing.T) {
+		p := &models.BackupPayload{
+			Version:      BackupVersion,
+			DatabaseType: "sqlite",
+		}
+		err := validatePayload(p)
+		if err != nil {
+			t.Fatalf("expected nil for empty entities, got %v", err)
+		}
+	})
+
+	t.Run("all entity types with empty required fields in one payload", func(t *testing.T) {
+		p := validMinimalPayload()
+		p.Entities.Appliances = append(p.Entities.Appliances, models.Appliance{})
+		err := validatePayload(p)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}
+
+func TestValidatePayload_Duplicates(t *testing.T) {
+	t.Run("duplicate appliance IDs", func(t *testing.T) {
+		p := validMinimalPayload()
+		p.Entities.Appliances = []models.Appliance{
+			{ApplianceName: "A", ID: 1},
+			{ApplianceName: "B", ID: 1},
+		}
+		err := validatePayload(p)
+		if err == nil {
+			t.Fatal("expected error for duplicate appliance IDs")
+		}
+	})
+
+	t.Run("duplicate todo IDs", func(t *testing.T) {
+		p := validMinimalPayload()
+		p.Entities.Todos = []models.Todo{
+			{UserID: "u", ID: 1},
+			{UserID: "v", ID: 1},
+		}
+		err := validatePayload(p)
+		if err == nil {
+			t.Fatal("expected error for duplicate todo IDs")
+		}
+	})
+
+	t.Run("duplicate maintenance IDs", func(t *testing.T) {
+		p := validMinimalPayload()
+		p.Entities.Maintenance = []models.Maintenance{
+			{Description: "A", Date: "2026-01-01", ID: 1},
+			{Description: "B", Date: "2026-01-02", ID: 1},
+		}
+		err := validatePayload(p)
+		if err == nil {
+			t.Fatal("expected error for duplicate maintenance IDs")
+		}
+	})
+
+	t.Run("duplicate repair IDs", func(t *testing.T) {
+		p := validMinimalPayload()
+		p.Entities.Repairs = []models.Repair{
+			{Description: "A", Date: "2026-01-01", ID: 1},
+			{Description: "B", Date: "2026-01-02", ID: 1},
+		}
+		err := validatePayload(p)
+		if err == nil {
+			t.Fatal("expected error for duplicate repair IDs")
+		}
+	})
+
+	t.Run("duplicate savedFile IDs", func(t *testing.T) {
+		p := validMinimalPayload()
+		p.Entities.SavedFiles = []models.SavedFile{
+			{Path: "./a", OriginalName: "a", UserID: "u", ID: 1},
+			{Path: "./b", OriginalName: "b", UserID: "v", ID: 1},
+		}
+		err := validatePayload(p)
+		if err == nil {
+			t.Fatal("expected error for duplicate savedFile IDs")
+		}
+	})
+
+	t.Run("duplicate note IDs", func(t *testing.T) {
+		p := validMinimalPayload()
+		p.Entities.Notes = []models.Note{
+			{Body: "note1", ID: 1},
+			{Body: "note2", ID: 1},
+		}
+		err := validatePayload(p)
+		if err == nil {
+			t.Fatal("expected error for duplicate note IDs")
+		}
+	})
+
+	t.Run("duplicate task IDs", func(t *testing.T) {
+		p := validMinimalPayload()
+		p.Entities.Tasks = []models.Task{
+			{Label: "task1", ID: 1},
+			{Label: "task2", ID: 1},
+		}
+		err := validatePayload(p)
+		if err == nil {
+			t.Fatal("expected error for duplicate task IDs")
+		}
+	})
+}
+
+func TestValidateUploads(t *testing.T) {
+	t.Run("empty uploadsDir skips validation", func(t *testing.T) {
+		p := validMinimalPayload()
+		err := validateUploads(p, "")
+		if err != nil {
+			t.Fatalf("expected nil for empty uploadsDir, got %v", err)
+		}
+	})
+
+	t.Run("all files exist", func(t *testing.T) {
+		dir := t.TempDir()
+		rel := "1"
+		os.MkdirAll(filepath.Join(dir, filepath.Dir(rel)), 0755)
+		os.WriteFile(filepath.Join(dir, rel), []byte("data"), 0644)
+
+		p := &models.BackupPayload{
+			Version:      BackupVersion,
+			DatabaseType: "sqlite",
+			Entities: models.Entities{
+				SavedFiles: []models.SavedFile{
+					{Path: "./data/uploads/1", OriginalName: "doc.pdf", UserID: "u"},
+				},
+			},
+		}
+		err := validateUploads(p, dir)
+		if err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		dir := t.TempDir()
+		p := &models.BackupPayload{
+			Version:      BackupVersion,
+			DatabaseType: "sqlite",
+			Entities: models.Entities{
+				SavedFiles: []models.SavedFile{
+					{Path: "./data/uploads/missing-file", OriginalName: "doc.pdf", UserID: "u"},
+				},
+			},
+		}
+		err := validateUploads(p, dir)
+		if err == nil {
+			t.Fatal("expected error for missing file")
+		}
+	})
+
+	t.Run("uploadsDir does not exist on disk", func(t *testing.T) {
+		p := &models.BackupPayload{
+			Version:      BackupVersion,
+			DatabaseType: "sqlite",
+			Entities: models.Entities{
+				SavedFiles: []models.SavedFile{
+					{Path: "./data/uploads/1", OriginalName: "doc.pdf", UserID: "u"},
+				},
+			},
+		}
+		err := validateUploads(p, "./nonexistent-dir")
+		if err == nil {
+			t.Fatal("expected error for non-existent uploads dir")
+		}
+	})
+
+	t.Run("no saved files should pass", func(t *testing.T) {
+		dir := t.TempDir()
+		p := &models.BackupPayload{
+			Version:      BackupVersion,
+			DatabaseType: "sqlite",
+		}
+		err := validateUploads(p, dir)
+		if err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("savedFile with empty path is skipped", func(t *testing.T) {
+		dir := t.TempDir()
+		p := &models.BackupPayload{
+			Version:      BackupVersion,
+			DatabaseType: "sqlite",
+			Entities: models.Entities{
+				SavedFiles: []models.SavedFile{
+					{Path: "", OriginalName: "doc.pdf", UserID: "u"},
+				},
+			},
+		}
+		err := validateUploads(p, dir)
+		if err != nil {
+			t.Fatalf("expected nil for savedFile with empty path, got %v", err)
+		}
+	})
+}

--- a/server/internal/database/legacy_import.go
+++ b/server/internal/database/legacy_import.go
@@ -78,12 +78,12 @@ func ConvertLegacyDB(dbPath string) (*models.BackupPayload, error) {
 	// have orphaned FK references (e.g. maintenance.appliance_id pointing to a
 	// non-existent or hard-deleted appliance). NIL out any FK that doesn't
 	// resolve to a record in the payload to avoid FK violations on Postgres.
-	sanitizeFKs(payload)
+	SanitizeFKs(payload)
 
 	return payload, nil
 }
 
-func sanitizeFKs(payload *models.BackupPayload) {
+func SanitizeFKs(payload *models.BackupPayload) {
 	validApplianceIDs := make(map[uint]struct{}, len(payload.Entities.Appliances))
 	for _, a := range payload.Entities.Appliances {
 		validApplianceIDs[a.ID] = struct{}{}

--- a/server/internal/database/legacy_import_test.go
+++ b/server/internal/database/legacy_import_test.go
@@ -1,0 +1,264 @@
+package database
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"github.com/masoncfrancis/homelogger/server/internal/models"
+	"gorm.io/gorm"
+)
+
+func createLegacyDB(t *testing.T, tables map[string]bool) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "legacy.db")
+
+	db, err := gorm.Open(sqlite.Open(path), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open legacy db: %v", err)
+	}
+
+	if tables["appliances"] {
+		db.Exec(`CREATE TABLE appliances (id INTEGER PRIMARY KEY, appliance_name TEXT, manufacturer TEXT, model_number TEXT, serial_number TEXT, year_purchased TEXT, purchase_price TEXT, location TEXT, type TEXT, "createdAt" DATETIME, "updatedAt" DATETIME, "deletedAt" DATETIME)`)
+		db.Exec(`INSERT INTO appliances (id, appliance_name, manufacturer) VALUES (1, 'Old Fridge', 'Acme')`)
+	}
+
+	if tables["todos"] {
+		db.Exec(`CREATE TABLE todos (id INTEGER PRIMARY KEY, label TEXT, checked BOOLEAN, userid TEXT, "createdAt" DATETIME, "updatedAt" DATETIME, "deletedAt" DATETIME)`)
+		db.Exec(`INSERT INTO todos (id, label, checked, userid) VALUES (1, 'Buy filter', 0, 'u1')`)
+	}
+
+	if tables["tasks"] {
+		db.Exec(`CREATE TABLE tasks (id INTEGER PRIMARY KEY, label TEXT, userid TEXT, "createdAt" DATETIME, "updatedAt" DATETIME, "deletedAt" DATETIME)`)
+		db.Exec(`INSERT INTO tasks (id, label, userid) VALUES (1, 'Replace filter', 'u1')`)
+	}
+
+	if tables["maintenances"] {
+		db.Exec(`CREATE TABLE maintenances (id INTEGER PRIMARY KEY, description TEXT, date TEXT, cost REAL, notes TEXT, space_type TEXT, reference_type TEXT, appliance_id INTEGER, "createdAt" DATETIME, "updatedAt" DATETIME, "deletedAt" DATETIME)`)
+		db.Exec(`INSERT INTO maintenances (id, description, date) VALUES (1, 'Filter change', '2026-01-15')`)
+	}
+
+	if tables["repairs"] {
+		db.Exec(`CREATE TABLE repairs (id INTEGER PRIMARY KEY, description TEXT, date TEXT, cost REAL, notes TEXT, space_type TEXT, reference_type TEXT, appliance_id INTEGER, "createdAt" DATETIME, "updatedAt" DATETIME, "deletedAt" DATETIME)`)
+		db.Exec(`INSERT INTO repairs (id, description, date) VALUES (1, 'Fix leak', '2026-03-01')`)
+	}
+
+	if tables["saved_files"] {
+		db.Exec(`CREATE TABLE saved_files (id INTEGER PRIMARY KEY, path TEXT, original_name TEXT, type TEXT, userid TEXT, "createdAt" DATETIME, "updatedAt" DATETIME, "deletedAt" DATETIME)`)
+		db.Exec(`INSERT INTO saved_files (id, path, original_name, userid) VALUES (1, './data/uploads/1', 'doc.pdf', 'u1')`)
+	}
+
+	if tables["notes"] {
+		db.Exec(`CREATE TABLE notes (id INTEGER PRIMARY KEY, title TEXT, body TEXT, "createdAt" DATETIME, "updatedAt" DATETIME, "deletedAt" DATETIME)`)
+		db.Exec(`INSERT INTO notes (id, title, body) VALUES (1, 'Note 1', 'Body 1')`)
+	}
+
+	sqlDB, err := db.DB()
+	if err == nil {
+		sqlDB.Close()
+	}
+
+	return path
+}
+
+func TestConvertLegacyDB(t *testing.T) {
+	t.Run("all tables present", func(t *testing.T) {
+		path := createLegacyDB(t, map[string]bool{
+			"appliances":  true,
+			"todos":       true,
+			"tasks":       true,
+			"maintenances": true,
+			"repairs":     true,
+			"saved_files": true,
+			"notes":       true,
+		})
+
+		payload, err := ConvertLegacyDB(path)
+		if err != nil {
+			t.Fatalf("ConvertLegacyDB failed: %v", err)
+		}
+
+		if payload.Version != BackupVersion {
+			t.Errorf("expected version %q, got %q", BackupVersion, payload.Version)
+		}
+		if payload.DatabaseType != "sqlite" {
+			t.Errorf("expected databaseType sqlite, got %q", payload.DatabaseType)
+		}
+
+		if len(payload.Entities.Appliances) != 1 {
+			t.Errorf("expected 1 appliance, got %d", len(payload.Entities.Appliances))
+		}
+		if len(payload.Entities.Todos) != 1 {
+			t.Errorf("expected 1 todo, got %d", len(payload.Entities.Todos))
+		}
+		if len(payload.Entities.Tasks) != 1 {
+			t.Errorf("expected 1 task, got %d", len(payload.Entities.Tasks))
+		}
+		if len(payload.Entities.Maintenance) != 1 {
+			t.Errorf("expected 1 maintenance, got %d", len(payload.Entities.Maintenance))
+		}
+		if len(payload.Entities.Repairs) != 1 {
+			t.Errorf("expected 1 repair, got %d", len(payload.Entities.Repairs))
+		}
+		if len(payload.Entities.SavedFiles) != 1 {
+			t.Errorf("expected 1 savedFile, got %d", len(payload.Entities.SavedFiles))
+		}
+		if len(payload.Entities.Notes) != 1 {
+			t.Errorf("expected 1 note, got %d", len(payload.Entities.Notes))
+		}
+	})
+
+	t.Run("missing tables skipped gracefully", func(t *testing.T) {
+		path := createLegacyDB(t, map[string]bool{
+			"appliances": true,
+		})
+
+		payload, err := ConvertLegacyDB(path)
+		if err != nil {
+			t.Fatalf("ConvertLegacyDB failed: %v", err)
+		}
+
+		if len(payload.Entities.Appliances) != 1 {
+			t.Errorf("expected 1 appliance, got %d", len(payload.Entities.Appliances))
+		}
+		if len(payload.Entities.Tasks) != 0 {
+			t.Errorf("expected 0 tasks (no table), got %d", len(payload.Entities.Tasks))
+		}
+		if len(payload.Entities.Notes) != 0 {
+			t.Errorf("expected 0 notes (no table), got %d", len(payload.Entities.Notes))
+		}
+	})
+}
+
+func TestSanitizeFKs(t *testing.T) {
+	t.Run("orphaned appliance FK on maintenance is nilled", func(t *testing.T) {
+		payload := &models.BackupPayload{
+			Entities: models.Entities{
+				Maintenance: []models.Maintenance{
+					{ApplianceID: uintPtr(99)}, // no appliance with ID 99
+				},
+			},
+		}
+		SanitizeFKs(payload)
+		if payload.Entities.Maintenance[0].ApplianceID != nil {
+			t.Error("expected ApplianceID to be nil")
+		}
+	})
+
+	t.Run("valid appliance FK on maintenance is preserved", func(t *testing.T) {
+		payload := &models.BackupPayload{
+			Entities: models.Entities{
+				Appliances: []models.Appliance{
+					{ApplianceName: "Fridge", ID: 1},
+				},
+				Maintenance: []models.Maintenance{
+					{ApplianceID: uintPtr(1)},
+				},
+			},
+		}
+		SanitizeFKs(payload)
+		if payload.Entities.Maintenance[0].ApplianceID == nil || *payload.Entities.Maintenance[0].ApplianceID != 1 {
+			t.Error("expected ApplianceID to remain 1")
+		}
+	})
+
+	t.Run("orphaned attachment FK on repair is nilled", func(t *testing.T) {
+		payload := &models.BackupPayload{
+			Entities: models.Entities{
+				Repairs: []models.Repair{
+					{AttachmentID: uintPtr(99)},
+				},
+			},
+		}
+		SanitizeFKs(payload)
+		if payload.Entities.Repairs[0].AttachmentID != nil {
+			t.Error("expected AttachmentID to be nil")
+		}
+	})
+
+	t.Run("orphaned attachment FK on maintenance is nilled", func(t *testing.T) {
+		payload := &models.BackupPayload{
+			Entities: models.Entities{
+				Maintenance: []models.Maintenance{
+					{AttachmentID: uintPtr(99)},
+				},
+			},
+		}
+		SanitizeFKs(payload)
+		if payload.Entities.Maintenance[0].AttachmentID != nil {
+			t.Error("expected AttachmentID to be nil")
+		}
+	})
+
+	t.Run("orphaned appliance FK on savedFile is nilled", func(t *testing.T) {
+		payload := &models.BackupPayload{
+			Entities: models.Entities{
+				SavedFiles: []models.SavedFile{
+					{ApplianceID: uintPtr(99)},
+				},
+			},
+		}
+		SanitizeFKs(payload)
+		if payload.Entities.SavedFiles[0].ApplianceID != nil {
+			t.Error("expected ApplianceID to be nil")
+		}
+	})
+
+	t.Run("orphaned maintenance FK on savedFile is nilled", func(t *testing.T) {
+		payload := &models.BackupPayload{
+			Entities: models.Entities{
+				SavedFiles: []models.SavedFile{
+					{MaintenanceID: uintPtr(99)},
+				},
+			},
+		}
+		SanitizeFKs(payload)
+		if payload.Entities.SavedFiles[0].MaintenanceID != nil {
+			t.Error("expected MaintenanceID to be nil")
+		}
+	})
+
+	t.Run("orphaned repair FK on savedFile is nilled", func(t *testing.T) {
+		payload := &models.BackupPayload{
+			Entities: models.Entities{
+				SavedFiles: []models.SavedFile{
+					{RepairID: uintPtr(99)},
+				},
+			},
+		}
+		SanitizeFKs(payload)
+		if payload.Entities.SavedFiles[0].RepairID != nil {
+			t.Error("expected RepairID to be nil")
+		}
+	})
+
+	t.Run("orphaned appliance FK on note is nilled", func(t *testing.T) {
+		payload := &models.BackupPayload{
+			Entities: models.Entities{
+				Notes: []models.Note{
+					{ApplianceID: uintPtr(99)},
+				},
+			},
+		}
+		SanitizeFKs(payload)
+		if payload.Entities.Notes[0].ApplianceID != nil {
+			t.Error("expected ApplianceID to be nil")
+		}
+	})
+
+	t.Run("orphaned appliance FK on task is nilled", func(t *testing.T) {
+		payload := &models.BackupPayload{
+			Entities: models.Entities{
+				Tasks: []models.Task{
+					{ApplianceID: uintPtr(99)},
+				},
+			},
+		}
+		SanitizeFKs(payload)
+		if payload.Entities.Tasks[0].ApplianceID != nil {
+			t.Error("expected ApplianceID to be nil")
+		}
+	})
+}
+
+

--- a/server/internal/models/backup.go
+++ b/server/internal/models/backup.go
@@ -23,6 +23,7 @@ type Entities struct {
 
 // ImportResult summarizes the results of an import operation.
 type ImportResult struct {
+	ImportID     string `json:"importId,omitempty"`
 	Inserted     int    `json:"inserted"`
 	Updated      int    `json:"updated"`
 	Skipped      int    `json:"skipped"`

--- a/server/internal/models/backup.go
+++ b/server/internal/models/backup.go
@@ -31,4 +31,12 @@ type ImportResult struct {
 	ErrorMessage string `json:"errorMessage,omitempty"`
 }
 
+// GetImportID returns ImportID safely, even on nil receiver.
+func (r *ImportResult) GetImportID() string {
+	if r == nil {
+		return ""
+	}
+	return r.ImportID
+}
+
 

--- a/server/internal/version/version.go
+++ b/server/internal/version/version.go
@@ -3,4 +3,4 @@ package version
 // Version is the application version. It can be overridden at build time using:
 //
 //	-ldflags "-X github.com/masoncfrancis/homelogger/server/internal/version.Version=..."
-var Version = "v0.5.0"
+var Version = "v0.5.0/"

--- a/server/internal/version/version.go
+++ b/server/internal/version/version.go
@@ -3,4 +3,4 @@ package version
 // Version is the application version. It can be overridden at build time using:
 //
 //	-ldflags "-X github.com/masoncfrancis/homelogger/server/internal/version.Version=..."
-var Version = "v0.5.0/"
+var Version = "v0.5.0"

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -38,6 +38,10 @@ paths:
                   demo:
                     type: boolean
                     example: true
+                  importing:
+                    type: boolean
+                    example: false
+                    description: True when the server is currently restoring a backup
   /task:
     get:
       summary: Get tasks (optionally filtered by appliance or space)
@@ -1191,9 +1195,18 @@ paths:
     post:
       summary: Import a ZIP backup of the application data
       description: |
-        Accepts a ZIP file containing `data.json` and optionally an `uploads/` directory.
-        This operation performs a "wipe and replace" strategy: all existing database data
-        and uploaded files will be deleted and replaced with the contents of the backup.
+        Accepts a ZIP file containing `data.json` at the root level and optionally an
+        `uploads/` directory at the root level. This operation performs a "wipe and
+        replace" strategy: all existing database data and uploaded files will be deleted
+        and replaced with the contents of the backup.
+
+        Required ZIP structure:
+          - data.json must be at the root of the archive (not nested in subdirectories)
+          - uploads/ (if present) must be at the root of the archive
+          - Legacy .db files must be in a db/ directory at the root
+
+        While an import is in progress, all /api/* endpoints except /api/health and
+        /api/backup/import return a 503 status with {"status": "busy"}.
       requestBody:
         required: true
         content:
@@ -1213,29 +1226,64 @@ paths:
               schema:
                 type: object
                 properties:
-                  message:
+                  status:
                     type: string
-                    example: "Backup import completed successfully"
+                    example: "completed"
+                  importId:
+                    type: string
+                    example: "imp_174234234234"
+                    description: Unique identifier for this import operation
+                  inserted:
+                    type: integer
+                    example: 42
+                    description: Total number of records inserted
         "400":
-          description: Invalid backup file or missing data.json
+          description: |
+            Invalid backup file. Possible causes:
+              - Missing data.json or legacy .db file
+              - data.json or uploads/ found inside a subdirectory instead of root
+              - Payload validation failure (missing required fields)
+              - Upload file reference in payload not found in extracted uploads/
           content:
             application/json:
               schema:
                 type: object
                 properties:
+                  status:
+                    type: string
+                    example: "failed"
                   error:
                     type: string
-                    example: "Invalid backup ZIP or missing data.json"
+                    example: "data.json was found inside \"subdir/data.json\" — place it at the root of the ZIP archive"
+        "503":
+          description: Import timed out, or another import is already in progress (though mutex prevents concurrent imports).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: "failed"
+                  error:
+                    type: string
+                    example: "Import timed out during ZIP extraction"
         "500":
-          description: Server error during import process.
+          description: Server error during import process (database error, file system error).
           content:
             application/json:
               schema:
                 type: object
                 properties:
+                  status:
+                    type: string
+                    example: "failed"
+                  importId:
+                    type: string
+                    example: "imp_174234234234"
                   error:
                     type: string
-                    example: "Error importing database data"
+                    example: "Error importing database data: invalid backup: appliance[0].applianceName: must not be empty"
   /notes:
     get:
       summary: Get notes (optionally filter by appliance or space)


### PR DESCRIPTION
## Description

Adds resiliency to imports (especially when importing from sqlite instance to a postgres instance)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Several tests have been added to the import logic flow


## API Changes

- The import endpoint more strictly specifies what structre a uploaded backup ZIP must be in. This structure is enforced by the endpoint. It has a new response format in JSON.  All other API endpoints (except health) return `504` while import is in progress. 
- The health endpoint now includes a json field for if an import is in progress.


## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] This is not an unsolicited PR. I have discussed this change with the maintainers and received approval to submit it.
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code



## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used in adding most resiiliency improvements. Code was validated and tested by the user before commission. 
